### PR TITLE
Warn for any existing files on init

### DIFF
--- a/cli/packages/graphcool-cli-core/src/commands/init/index.ts
+++ b/cli/packages/graphcool-cli-core/src/commands/init/index.ts
@@ -64,15 +64,13 @@ export default class Init extends Command {
       this.out.log(`
 The directory ${chalk.green(
         this.config.definitionDir,
-      )} contains files that could conflict:
+      )} is not empty.
 
-${files.map(f => `  ${f}`).join('\n')}
-
-Either try using a new directory name, or remove the files listed above.
+It is recommended to initialize your service in a new directory.
 
 ${chalk.bold(
         'NOTE:',
-      )} The behavior of the init command changed, to deploy a project, please use ${chalk.green(
+      )} The behavior of the init command changed, to deploy a service, please use ${chalk.green(
         'graphcool deploy',
       )}
 

--- a/cli/packages/graphcool-cli-core/src/commands/init/index.ts
+++ b/cli/packages/graphcool-cli-core/src/commands/init/index.ts
@@ -59,8 +59,7 @@ export default class Init extends Command {
     // CONTINUE: special env handling for dockaa. can't just override the host/dinges
     if (
       files.length > 0 &&
-      !(files.length === 1 && files[0] === '.graphcoolrc') &&
-      files.includes('graphcool.yml')
+      !(files.length === 1 && files[0] === '.graphcoolrc')
     ) {
       this.out.log(`
 The directory ${chalk.green(


### PR DESCRIPTION
This PR depends on:
- [ ] `proposal/accepted` on #1103

Fixes #1103. The current implementation only warns if there is a `graphcool.yml` file in the folder when running `gc init`. I extended that check to warn on any files in the folder. This fixes the issue with overwriting package.json, but better yet, it aligns with the recommendation to always create your Graphcool project in an empty folder. The warning message is also updated accordingly.