### PR TITLE
[WIP] Added validation for event payload

### DIFF
--- a/cli/packages/graphcool-cli-core/typings.d.ts
+++ b/cli/packages/graphcool-cli-core/typings.d.ts
@@ -1,0 +1,4 @@
+declare module "*.json" {
+  const value: any;
+  export default value;
+}


### PR DESCRIPTION
Do not merge directly. This PR depends on:

- [ ] PR for graphcool-json-schema: graphcool/graphcool-json-schema#6
- [ ] Release new `graphcool-json-schema` version and update dependencies in CLI packages
- [ ] `proposal/accepted` on #1240

This adds validation of the event payload for `gc invoke-local` using the new schema in `graphcool-json-schema`.

Fixes #1240 