### PR TITLE
fix messaging for 'potentially destructive changes' error in cli

### DIFF
--- a/server/backend-api-system/src/main/scala/cool/graph/system/migration/dataSchema/validation/SchemaErrors.scala
+++ b/server/backend-api-system/src/main/scala/cool/graph/system/migration/dataSchema/validation/SchemaErrors.scala
@@ -141,7 +141,7 @@ object SchemaErrors {
 
   // note: the cli relies on the string "destructive changes" being present in this error message. Ugly but effective
   def forceArgumentRequired: SchemaError = {
-    SchemaError.global("Your migration includes potentially destructive changes. Review using `graphcool deploy --dry-run` and continue using `graphcool deploy --force`.")
+    SchemaError.global("Your migration includes potentially destructive changes. Review using `graphcool-framework deploy --dry-run` and continue using `graphcool-framework deploy --force`.")
   }
 
   def invalidEnv(message: String) = {


### PR DESCRIPTION
Looks like the correct message should use 'graphcool-framework' rather than simply 'graphcool'