### PR TITLE
fix type description to Json from JSON on docs

### DIFF
--- a/docs/0.x/04-Reference/03-Database/02-Data-Modelling.md
+++ b/docs/0.x/04-Reference/03-Database/02-Data-Modelling.md
@@ -179,13 +179,13 @@ Note: Enum values can at most be 191 characters long.
 
 In queries or mutations, Enum fields have to be specified without any enclosing characters. You can only use values that you defined for the enum: `enum: COMPACT`, `enum: WIDE`.
 
-#### JSON
+#### Json
 
-Sometimes you need to store arbitrary JSON values for loosely structured data. The JSON type makes sure that it is actually valid JSON and returns the value as a parsed JSON object/array instead of a string.
+Sometimes you need to store arbitrary Json values for loosely structured data. The Json type makes sure that it is actually valid json and returns the value as a parsed Json object/array instead of a string.
 
-Note: JSON values are currently limited to 256KB in size.
+Note: Json values are currently limited to 256KB in size.
 
-In queries or mutations, JSON fields have to be specified with enclosing double quotes. Special characters have to be escaped: `json: "{\"int\": 1, \"string\": \"value\"}"`.
+In queries or mutations, Json fields have to be specified with enclosing double quotes. Special characters have to be escaped: `json: "{\"int\": 1, \"string\": \"value\"}"`.
 
 <!--
 #### GeoPoint

--- a/docs/1.0/04-Reference/03-Database/01-Data-Modelling-(SDL).md
+++ b/docs/1.0/04-Reference/03-Database/01-Data-Modelling-(SDL).md
@@ -202,13 +202,13 @@ Note: Enum values can at most be 191 characters long.
 
 In queries or mutations, Enum fields have to be specified without any enclosing characters. You can only use values that you defined for the enum: `enum: COMPACT`, `enum: WIDE`.
 
-#### JSON
+#### Json
 
-Sometimes you need to store arbitrary JSON values for loosely structured data. The JSON type makes sure that it is actually valid JSON and returns the value as a parsed JSON object/array instead of a string.
+Sometimes you need to store arbitrary Json values for loosely structured data. The Json type makes sure that it is actually valid Json and returns the value as a parsed Json object/array instead of a string.
 
-Note: JSON values are currently limited to 256KB in size on the shared demo cluster. This limit can be increased on other clusters using [the cluster configuration](https://github.com/graphcool/framework/issues/748).
+Note: Json values are currently limited to 256KB in size on the shared demo cluster. This limit can be increased on other clusters using [the cluster configuration](https://github.com/graphcool/framework/issues/748).
 
-In queries or mutations, JSON fields have to be specified with enclosing double quotes. Special characters have to be escaped: `json: "{\"int\": 1, \"string\": \"value\"}"`.
+In queries or mutations, Json fields have to be specified with enclosing double quotes. Special characters have to be escaped: `json: "{\"int\": 1, \"string\": \"value\"}"`.
 
 #### ID
 


### PR DESCRIPTION
Graphcool provides Json type is Json, not JSON.
It causes confused usage.

I think it is better to fix it as match actually data type.