### PR TITLE
Update links to graphql-yoga examples

### DIFF
--- a/docs/1.0/06-GraphQL-Ecosystem/01-GraphQL-Yoga/01-Overview.md
+++ b/docs/1.0/06-GraphQL-Ecosystem/01-GraphQL-Yoga/01-Overview.md
@@ -160,9 +160,9 @@ See the original documentation in [`graphql-subscriptions`](https://github.com/a
 
 There are three examples demonstrating how to quickly get started with `graphql-yoga`:
 
-- [hello-world](./examples/hello-world): Basic setup for building a schema and allowing for a `hello` query.
-- [subscriptions](./examples/subscriptions): Basic setup for using subscriptions with a counter that increments every 2 seconds and triggers a subscriptions.
-- [fullstack](./examples/fullstack): Fullstack example based on [`create-react-app`](https://github.com/facebookincubator/create-react-app) demonstrating how to query data from `graphql-yoga` with [Apollo Client 2.0](https://www.apollographql.com/client/).
+- [hello-world](https://github.com/graphcool/graphql-yoga/tree/master/examples/hello-world): Basic setup for building a schema and allowing for a `hello` query.
+- [subscriptions](https://github.com/graphcool/graphql-yoga/tree/master/examples/subscriptions): Basic setup for using subscriptions with a counter that increments every 2 seconds and triggers a subscriptions.
+- [fullstack](https://github.com/graphcool/graphql-yoga/tree/master/examples/fullstack): Fullstack example based on [`create-react-app`](https://github.com/facebookincubator/create-react-app) demonstrating how to query data from `graphql-yoga` with [Apollo Client 2.0](https://www.apollographql.com/client/).
 
 ## Workflow
 


### PR DESCRIPTION
I found a few links that were out of date and updated them to go to the new locations.