### PR TITLE
Relations that did not have two relation fields cause error in relation checks

### DIFF
--- a/server/api/src/main/scala/com/prisma/api/database/mutactions/mutactions/NestedRelationMutactionBaseClass.scala
+++ b/server/api/src/main/scala/com/prisma/api/database/mutactions/mutactions/NestedRelationMutactionBaseClass.scala
@@ -19,8 +19,13 @@ trait NestedRelationMutactionBaseClass extends ClientSqlDataChangeMutaction {
   def where: NodeSelector
   def topIsCreate: Boolean
 
-  val p = parentInfo.field
-  val c = parentInfo.relation.getOtherModel_!(project.schema, parentInfo.where.model).fields.find(_.relation.contains(parentInfo.relation)).get
+  val p                = parentInfo.field
+  val otherModel       = parentInfo.relation.getOtherModel_!(project.schema, parentInfo.where.model)
+  val otherFieldOption = otherModel.fields.find(_.relation.contains(parentInfo.relation))
+  val c = otherFieldOption match {
+    case Some(x) => x
+    case None    => p.copy(isRequired = false, isList = true) //optional backrelation defaults to List-NonRequired
+  }
 
   val checkForOldParent = oldParentFailureTriggerForRequiredRelations(project, parentInfo.relation, where)
   val checkForOldChild  = oldChildFailureTriggerForRequiredRelations(project, parentInfo)


### PR DESCRIPTION
We were assuming that a relation always has two relationfields, but recently switched to optional backrelations, which is why this check was causing errors. We will now assume for the checks that the side without a relationfield is a list and is not required. Fixes https://github.com/graphcool/prisma/issues/1754