### PR TITLE
docs: fix wrong query argument

### DIFF
--- a/docs/1.1/04-Reference/02-Prisma-API/02-Concepts.md
+++ b/docs/1.1/04-Reference/02-Prisma-API/02-Concepts.md
@@ -55,7 +55,7 @@ Here are a few scenarios where node selection is required.
 ```graphql
 query {
   post(where: {
-    id: "ohco0iewee6eizidohwigheif"
+    email: "hello@graph.cool"
   }) {
     id
   }


### PR DESCRIPTION
This is just a documentation fix. The headline says `Retrieve a single node by its email`, but the example passes an `id` as the argument.