### PR TITLE
docs proposal: switch to bool default value

### DIFF
--- a/docs/1.1/04-Reference/01-Service-Configuration/03-Data-Modelling-(SDL).md
+++ b/docs/1.1/04-Reference/01-Service-Configuration/03-Data-Modelling-(SDL).md
@@ -347,7 +347,7 @@ To specify a default value for a field, you can use the `@default` directive:
 
 ```graphql
 type Story {
-  isPublished: Boolean @default(value: "false")
+  isPublished: Boolean @default(value: false)
   someNumber: Int! @default(value: "42")
   title: String! @default(value: "My New Post")
   publishDate: DateTime! @default(value: "2018-01-26")


### PR DESCRIPTION
Even if both is working, I think that defining the actual `bool` default value NOT as a string might be less confusing. I just stumbled upon this one and thought: "Ha, why is that a 'string'?". Just my opinion and I thought that you might be interested in my thought process :) Feel free to close this PR if you want to stick with the string definition :)