### PR TITLE
Update and Upsert missing in nested API

### DIFF
--- a/server/api/src/main/scala/com/prisma/api/database/DatabaseMutationBuilder.scala
+++ b/server/api/src/main/scala/com/prisma/api/database/DatabaseMutationBuilder.scala
@@ -117,14 +117,14 @@ object DatabaseMutationBuilder {
       updateArgs: CoolArgs,
       create: Vector[DBIOAction[Any, NoStream, Effect]],
       update: Vector[DBIOAction[Any, NoStream, Effect]],
+      createCheck: NestedCreateRelationMutaction
   ) = {
 
     val q       = DatabaseQueryBuilder.existsNodeIsInRelationshipWith(project, parentInfo, where).as[Boolean]
-    val qChecks = NestedCreateRelationMutaction(project, parentInfo, createWhere, false)
     val qInsert = DBIOAction.seq(createDataItem(project.id, where.model.name, createArgs), createRelayRow(project.id, createWhere), DBIOAction.seq(create: _*))
     val qUpdate = DBIOAction.seq(updateDataItemByUnique(project.id, where, updateArgs), DBIOAction.seq(update: _*))
 
-    ifThenElseNestedUpsert(q, qUpdate, qInsert, qChecks)
+    ifThenElseNestedUpsert(q, qUpdate, qInsert, createCheck)
   }
   //endregion
 

--- a/server/api/src/main/scala/com/prisma/api/database/mutactions/mutactions/NestedRelationMutactionBaseClass.scala
+++ b/server/api/src/main/scala/com/prisma/api/database/mutactions/mutactions/NestedRelationMutactionBaseClass.scala
@@ -43,8 +43,9 @@ trait NestedRelationMutactionBaseClass extends ClientSqlDataChangeMutaction {
 
   def addAction: List[DBIOAction[_, NoStream, Effect]]
 
+  def allActions = requiredCheck ++ removalActions ++ addAction
+
   override def execute = {
-    val allActions = requiredCheck ++ removalActions ++ addAction
     Future.successful(ClientSqlStatementResult(DBIOAction.seq(allActions: _*)))
   }
 

--- a/server/api/src/main/scala/com/prisma/api/database/mutactions/mutactions/UpsertDataItem.scala
+++ b/server/api/src/main/scala/com/prisma/api/database/mutactions/mutactions/UpsertDataItem.scala
@@ -29,7 +29,9 @@ case class UpsertDataItem(
   override def execute: Future[ClientSqlStatementResult[Any]] = {
     val createActions = SqlMutactions(dataResolver).getDbActionsForUpsertScalarLists(createWhere, allArgs.createArgumentsAsCoolArgs)
     val updateActions = SqlMutactions(dataResolver).getDbActionsForUpsertScalarLists(updateWhere, allArgs.updateArgumentsAsCoolArgs)
-    Future.successful { ClientSqlStatementResult(DatabaseMutationBuilder.upsert(project.id, where, createArgs, updateArgs, createActions, updateActions)) }
+    Future.successful {
+      ClientSqlStatementResult(DatabaseMutationBuilder.upsert(project.id, where, createWhere, createArgs, updateArgs, createActions, updateActions))
+    }
   }
 
   override def handleErrors = {

--- a/server/api/src/main/scala/com/prisma/api/database/mutactions/mutactions/UpsertDataItem.scala
+++ b/server/api/src/main/scala/com/prisma/api/database/mutactions/mutactions/UpsertDataItem.scala
@@ -43,6 +43,7 @@ case class UpsertDataItem(
       case e: SQLIntegrityConstraintViolationException if e.getErrorCode == 1048 => APIErrors.FieldCannotBeNull()
     })
   }
+
   override def verify(resolver: DataResolver): Future[Try[MutactionVerificationSuccess]] = {
     val (createCheck, _) = InputValueValidation.validateDataItemInputs(model, createArgs)
     val (updateCheck, _) = InputValueValidation.validateDataItemInputs(model, updateArgs)

--- a/server/api/src/main/scala/com/prisma/api/mutations/SqlMutactions.scala
+++ b/server/api/src/main/scala/com/prisma/api/mutations/SqlMutactions.scala
@@ -211,8 +211,8 @@ case class SqlMutactions(dataResolver: DataResolver) {
       val scalarListsUpdate = getDbActionsForUpsertScalarLists(currentWhere(upsert.where, upsert.update), upsert.update)
       val upsertItem =
         UpsertDataItemIfInRelationWith(project, parentInfo, upsert.where, createWhere, createArgsWithId, upsert.update, scalarListsCreate, scalarListsUpdate)
-      val addToRelation = AddDataItemToManyRelationByUniqueField(project, parentInfo, createWhere)
-      Vector(upsertItem, addToRelation) //++ getMutactionsForNestedMutation(upsert.update, upsert.where, triggeredFromCreate = false) ++
+
+      Vector(upsertItem) //++ getMutactionsForNestedMutation(upsert.update, upsert.where, triggeredFromCreate = false) ++
     //getMutactionsForNestedMutation(upsert.create, createWhere, triggeredFromCreate = true)
     }
   }

--- a/server/api/src/main/scala/com/prisma/api/schema/InputTypesBuilder.scala
+++ b/server/api/src/main/scala/com/prisma/api/schema/InputTypesBuilder.scala
@@ -97,11 +97,15 @@ abstract class UncachedInputTypesBuilder(project: Project) extends InputTypesBui
     val updateDataInput = computeInputObjectTypeForNestedUpdateData(model, omitRelation)
 
     for {
-      field    <- omitRelation.getField(project.schema, model)
       whereArg <- computeInputObjectTypeForWhereUnique(model)
     } yield {
+      val typeName = omitRelation.getField(project.schema, model) match {
+        case Some(field) => s"${model.name}UpdateWithout${field.name.capitalize}Input"
+        case None        => s"${model.name}UpdateInput"
+      }
+
       InputObjectType[Any](
-        name = s"${model.name}UpdateWithout${field.name.capitalize}Input",
+        name = typeName,
         fieldsFn = () => {
           List(
             InputField[Any]("where", whereArg),
@@ -129,12 +133,16 @@ abstract class UncachedInputTypesBuilder(project: Project) extends InputTypesBui
   protected def computeInputObjectTypeForNestedUpsert(model: Model, omitRelation: Relation): Option[InputObjectType[Any]] = {
 
     for {
-      field     <- omitRelation.getField(project.schema, model)
       whereArg  <- computeInputObjectTypeForWhereUnique(model)
       createArg <- computeInputObjectTypeForCreate(model, Some(omitRelation))
     } yield {
+      val typeName = omitRelation.getField(project.schema, model) match {
+        case Some(field) => s"${model.name}UpsertWithout${field.name.capitalize}Input"
+        case None        => s"${model.name}UpsertInput"
+      }
+
       InputObjectType[Any](
-        name = s"${model.name}UpsertWithout${field.name.capitalize}Input",
+        name = typeName,
         fieldsFn = () => {
           List(
             InputField[Any]("where", whereArg),

--- a/server/api/src/test/scala/com/prisma/api/mutations/NestedUpsertMutationInsideUpdateSpec.scala
+++ b/server/api/src/test/scala/com/prisma/api/mutations/NestedUpsertMutationInsideUpdateSpec.scala
@@ -1,10 +1,739 @@
 package com.prisma.api.mutations
 
 import com.prisma.api.ApiBaseSpec
+import com.prisma.api.database.DatabaseQueryBuilder
 import com.prisma.shared.schema_dsl.SchemaDsl
 import org.scalatest.{FlatSpec, Matchers}
 
 class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with ApiBaseSpec {
+
+  "a P1! to C1! relation" should "error  on create since old required parent relation would be broken" in {
+    val project = SchemaDsl() { schema =>
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      val child  = schema.model("Child").field_!("c", _.String, isUnique = true)
+      child.oneToOneRelation_!("parentReq", "childReq", parent)
+    }
+    database.setup(project)
+
+    val res = server
+      .executeQuerySimple(
+        """mutation {
+          |  createParent(data: {
+          |    p: "p1"
+          |    childReq: {
+          |      create: {c: "c1"}
+          |    }
+          |  }){
+          |    id
+          |    childReq{
+          |       id
+          |    }
+          |  }
+          |}""".stripMargin,
+        project
+      )
+
+    val parentId = res.pathAsString("data.createParent.id")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+
+    server.executeQuerySimpleThatMustFail(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where: {id: "$parentId"}
+         |  data:{
+         |    p: "p2"
+         |    childReq: {upsert: {
+         |    where: {c: "DOES NOT EXIST"}
+         |    update: {c: "DOES NOT MATTER"}
+         |    create :{c: "SomeC"}
+         |    }}
+         |  }){
+         |  p
+         |  childReq {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project,
+      errorCode = 3042,
+      errorContains = "The change you are trying to make would violate the required relation '_ChildToParent' between Child and Parent"
+    )
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+  }
+
+  "a P1! to C1! relation" should "succeed on update" in {
+    val project = SchemaDsl() { schema =>
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      val child  = schema.model("Child").field_!("c", _.String, isUnique = true)
+      child.oneToOneRelation_!("parentReq", "childReq", parent)
+    }
+    database.setup(project)
+
+    val res = server
+      .executeQuerySimple(
+        """mutation {
+          |  createParent(data: {
+          |    p: "p1"
+          |    childReq: {
+          |      create: {c: "c1"}
+          |    }
+          |  }){
+          |    id
+          |    childReq{
+          |       id
+          |    }
+          |  }
+          |}""".stripMargin,
+        project
+      )
+
+    val parentId = res.pathAsString("data.createParent.id")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+
+    val res2 = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where: {id: "$parentId"}
+         |  data:{
+         |    p: "p2"
+         |    childReq: {upsert: {
+         |    where: {c: "c1"}
+         |    update: {c: "New c"}
+         |    create :{c: "DOES NOT MATTER"}
+         |    }}
+         |  }){
+         |  p
+         |  childReq {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res2.toString should be("""{"data":{"updateParent":{"p":"p2","childReq":{"c":"New c"}}}}""")
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+  }
+
+  "a P1! to C1 relation" should "work on create" in {
+    val project = SchemaDsl() { schema =>
+      val child  = schema.model("Child").field_!("c", _.String, isUnique = true)
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      parent.oneToOneRelation_!("childReq", "parentOpt", child, isRequiredOnFieldB = false)
+    }
+    database.setup(project)
+
+    val res = server
+      .executeQuerySimple(
+        """mutation {
+          |  createParent(data: {
+          |    p: "p1"
+          |    childReq: {
+          |      create: {c: "c1"}
+          |    }
+          |  }){
+          |  id
+          |    childReq{
+          |       id
+          |    }
+          |  }
+          |}""".stripMargin,
+        project
+      )
+
+    val parentId = res.pathAsString("data.createParent.id")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+
+    val res2 = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where: {id: "$parentId"}
+         |  data:{
+         |    p: "p2"
+         |    childReq: {upsert: {
+         |    where: {c: "DOES NOT EXIST"}
+         |    update: {c: "DOES NOT MATTER"}
+         |    create :{c: "new C"}
+         |    }}
+         |  }){
+         |    childReq {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res2.toString should be("""{"data":{"updateParent":{"childReq":{"c":"new C"}}}}""")
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Parent").as[Int]) should be(Vector(1))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Child").as[Int]) should be(Vector(2))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+  }
+
+  "a P1! to C1 relation" should "work on update" in {
+    val project = SchemaDsl() { schema =>
+      val child  = schema.model("Child").field_!("c", _.String, isUnique = true)
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      parent.oneToOneRelation_!("childReq", "parentOpt", child, isRequiredOnFieldB = false)
+    }
+    database.setup(project)
+
+    val res = server
+      .executeQuerySimple(
+        """mutation {
+          |  createParent(data: {
+          |    p: "p1"
+          |    childReq: {
+          |      create: {c: "c1"}
+          |    }
+          |  }){
+          |  id
+          |    childReq{
+          |       id
+          |    }
+          |  }
+          |}""".stripMargin,
+        project
+      )
+
+    val parentId = res.pathAsString("data.createParent.id")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+
+    val res2 = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where: {id: "$parentId"}
+         |  data:{
+         |    p: "p2"
+         |    childReq: {upsert: {
+         |    where: {c: "c1"}
+         |    update: {c: "updated C"}
+         |    create :{c: "DOES NOT MATTER"}
+         |    }}
+         |  }){
+         |    childReq {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res2.toString should be("""{"data":{"updateParent":{"childReq":{"c":"updated C"}}}}""")
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Parent").as[Int]) should be(Vector(1))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Child").as[Int]) should be(Vector(1))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+  }
+
+  "a P1 to C1 relation" should "work on update" in {
+    val project = SchemaDsl() { schema =>
+      val child  = schema.model("Child").field_!("c", _.String, isUnique = true)
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      parent.oneToOneRelation("childOpt", "parentOpt", child)
+    }
+    database.setup(project)
+
+    val res = server
+      .executeQuerySimple(
+        """mutation {
+          |  createParent(data: {
+          |    p: "p1"
+          |    childOpt: {
+          |      create: {c: "c1"}
+          |    }
+          |  }){
+          |    id
+          |    childOpt{
+          |       id
+          |    }
+          |  }
+          |}""".stripMargin,
+        project
+      )
+
+    val parentId = res.pathAsString("data.createParent.id")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+
+    val res2 = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where:{id: "$parentId"}
+         |  data:{
+         |    p: "p2"
+         |    childOpt: {upsert: {
+         |    where: {c: "c1"}
+         |    update: {c: "updated C"}
+         |    create :{c: "DOES NOT MATTER"}
+         |    }}
+         |  }){
+         |    childOpt {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res2.toString should be("""{"data":{"updateParent":{"childOpt":{"c":"updated C"}}}}""")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Parent").as[Int]) should be(Vector(1))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Child").as[Int]) should be(Vector(1))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+  }
+
+  "a P1 to C1 relation" should "work on create" in {
+    val project = SchemaDsl() { schema =>
+      val child  = schema.model("Child").field_!("c", _.String, isUnique = true)
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      parent.oneToOneRelation("childOpt", "parentOpt", child)
+    }
+    database.setup(project)
+
+    val res = server
+      .executeQuerySimple(
+        """mutation {
+          |  createParent(data: {
+          |    p: "p1"
+          |    childOpt: {
+          |      create: {c: "c1"}
+          |    }
+          |  }){
+          |    id
+          |    childOpt{
+          |       id
+          |    }
+          |  }
+          |}""".stripMargin,
+        project
+      )
+
+    val parentId = res.pathAsString("data.createParent.id")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+
+    val res2 = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where:{id: "$parentId"}
+         |  data:{
+         |    p: "p2"
+         |    childOpt: {upsert: {
+         |    where: {c: "DOES NOT EXIST"}
+         |    update: {c: "DOES NOT MATTER"}
+         |    create :{c: "new C"}
+         |    }}
+         |  }){
+         |    childOpt {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res2.toString should be("""{"data":{"updateParent":{"childOpt":{"c":"new C"}}}}""")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Parent").as[Int]) should be(Vector(1))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Child").as[Int]) should be(Vector(2))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+  }
+
+  "a P1 to C1  relation with the parent without a relation" should "work with create" in {
+    val project = SchemaDsl() { schema =>
+      val child = schema.model("Child").field_!("c", _.String, isUnique = true)
+      schema.model("Parent").field_!("p", _.String, isUnique = true).oneToOneRelation("childOpt", "parentOpt", child)
+    }
+    database.setup(project)
+
+    val parent1Id = server
+      .executeQuerySimple(
+        """mutation {
+          |  createParent(data: {p: "p1"})
+          |  {
+          |    id
+          |  }
+          |}""".stripMargin,
+        project
+      )
+      .pathAsString("data.createParent.id")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(0))
+
+    val res = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where:{id: "$parent1Id"}
+         |  data:{
+         |    p: "p2"
+         |    childOpt: {upsert: {
+         |    where: {c: "DOES NOT EXIST"}
+         |    update: {c: "DOES NOT MATTER"}
+         |    create :{c: "new C"}
+         |    }}
+         |  }){
+         |    childOpt {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res.toString should be("""{"data":{"updateParent":{"childOpt":{"c":"new C"}}}}""")
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Parent").as[Int]) should be(Vector(1))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "Child").as[Int]) should be(Vector(1))
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+  }
+
+  "a PM to C1!  relation with a child already in a relation" should "work" ignore {
+    val project = SchemaDsl() { schema =>
+      val child = schema.model("Child").field_!("c", _.String, isUnique = true)
+      schema.model("Parent").field_!("p", _.String, isUnique = true).oneToManyRelation_!("childrenOpt", "parentReq", child)
+    }
+    database.setup(project)
+
+    server.executeQuerySimple(
+      """mutation {
+        |  createParent(data: {
+        |    p: "p1"
+        |    childrenOpt: {
+        |      create: {c: "c1"}
+        |    }
+        |  }){
+        |    childrenOpt{
+        |       c
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(1))
+
+    val res = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |    where: {p: "p1"}
+         |    data:{
+         |    childrenOpt: {create: {c: "c2"}}
+         |  }){
+         |    childrenOpt {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res.toString should be("""{"data":{"updateParent":{"childrenOpt":[{"c":"c1"},{"c":"c2"}]}}}""")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(2))
+  }
+
+  "a P1 to C1!  relation with the parent and a child already in a relation" should "error in a nested mutation by unique" ignore {
+    val project = SchemaDsl() { schema =>
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      schema.model("Child").field_!("c", _.String, isUnique = true).oneToOneRelation_!("parentReq", "childOpt", parent, isRequiredOnFieldB = false)
+    }
+    database.setup(project)
+
+    server.executeQuerySimple(
+      """mutation {
+        |  createParent(data: {
+        |    p: "p1"
+        |    childOpt: {
+        |      create: {c: "c1"}
+        |    }
+        |  }){
+        |    childOpt{
+        |       c
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+
+    server.executeQuerySimpleThatMustFail(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where: {p: "p1"}
+         |  data:{
+         |    childOpt: {create: {c: "c2"}}
+         |  }){
+         |    childOpt {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project,
+      errorCode = 3042,
+      errorContains = "The change you are trying to make would violate the required relation '_ChildToParent' between Child and Parent"
+    )
+  }
+
+  "a P1 to C1!  relation with the parent not already in a relation" should "work in a nested mutation by unique" ignore {
+    val project = SchemaDsl() { schema =>
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      schema.model("Child").field_!("c", _.String, isUnique = true).oneToOneRelation_!("parentReq", "childOpt", parent, isRequiredOnFieldB = false)
+    }
+    database.setup(project)
+
+    server.executeQuerySimple(
+      """mutation {
+        |  createParent(data: {
+        |    p: "p1"
+        |
+        |  }){
+        |    p
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(0))
+
+    val res = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where: {p: "p1"}
+         |  data:{
+         |    childOpt: {create: {c: "c1"}}
+         |  }){
+         |    childOpt {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res.toString should be("""{"data":{"updateParent":{"childOpt":{"c":"c1"}}}}""")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+  }
+
+  "a PM to C1  relation with the parent already in a relation" should "work through a nested mutation by unique" ignore {
+    val project = SchemaDsl() { schema =>
+      val child = schema.model("Child").field_!("c", _.String, isUnique = true)
+      schema.model("Parent").field_!("p", _.String, isUnique = true).oneToManyRelation("childrenOpt", "parentOpt", child)
+    }
+    database.setup(project)
+
+    server
+      .executeQuerySimple(
+        """mutation {
+          |  createParent(data: {
+          |    p: "p1"
+          |    childrenOpt: {
+          |      create: [{c: "c1"}, {c: "c2"}]
+          |    }
+          |  }){
+          |    childrenOpt{
+          |       c
+          |    }
+          |  }
+          |}""".stripMargin,
+        project
+      )
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(2))
+
+    val res = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where: { p: "p1"}
+         |  data:{
+         |    childrenOpt: {create: [{c: "c3"}]}
+         |  }){
+         |    childrenOpt {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res.toString should be("""{"data":{"updateParent":{"childrenOpt":[{"c":"c1"},{"c":"c2"},{"c":"c3"}]}}}""")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ParentToChild").as[Int]) should be(Vector(3))
+  }
+
+  "a P1! to CM  relation with the parent already in a relation" should "work through a nested mutation by unique" ignore {
+    val project = SchemaDsl() { schema =>
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      val child  = schema.model("Child").field_!("c", _.String, isUnique = true).oneToManyRelation_!("parentsOpt", "childReq", parent)
+    }
+    database.setup(project)
+
+    server.executeQuerySimple(
+      """mutation {
+        |  createParent(data: {
+        |    p: "p1"
+        |    childReq: {
+        |      create: {c: "c1"}
+        |    }
+        |  }){
+        |    childReq{
+        |       c
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+
+    val res = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where: {p: "p1"}
+         |  data:{
+         |    childReq: {create: {c: "c2"}}
+         |  }){
+         |    childReq {
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res.toString should be("""{"data":{"updateParent":{"childReq":{"c":"c2"}}}}""")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+  }
+
+  "a P1 to CM  relation with the child already in a relation" should "work through a nested mutation by unique" ignore {
+    val project = SchemaDsl() { schema =>
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      val child  = schema.model("Child").field_!("c", _.String, isUnique = true).oneToManyRelation("parentsOpt", "childOpt", parent)
+    }
+    database.setup(project)
+
+    server.executeQuerySimple(
+      """mutation {
+        |  createParent(data: {
+        |    p: "p1"
+        |    childOpt: {
+        |      create: {c: "c1"}
+        |    }
+        |  }){
+        |    childOpt{
+        |       c
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+
+    val res = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |    where: {p: "p1"}
+         |    data:{
+         |    childOpt: {create: {c: "c2"}}
+         |  }){
+         |    childOpt{
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res.toString should be("""{"data":{"updateParent":{"childOpt":{"c":"c2"}}}}""")
+
+    server.executeQuerySimple(s"""query{children{c, parentsOpt{p}}}""", project).toString should be(
+      """{"data":{"children":[{"c":"c1","parentsOpt":[]},{"c":"c2","parentsOpt":[{"p":"p1"}]}]}}""")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(1))
+  }
+
+  "a PM to CM  relation with the children already in a relation" should "be disconnectable through a nested mutation by unique" ignore {
+    val project = SchemaDsl() { schema =>
+      val parent = schema.model("Parent").field_!("p", _.String, isUnique = true)
+      val child  = schema.model("Child").field_!("c", _.String, isUnique = true).manyToManyRelation("parentsOpt", "childrenOpt", parent)
+    }
+    database.setup(project)
+
+    server.executeQuerySimple(
+      """mutation {
+        |  createParent(data: {
+        |    p: "p1"
+        |    childrenOpt: {
+        |      create: [{c: "c1"},{c: "c2"}]
+        |    }
+        |  }){
+        |    childrenOpt{
+        |       c
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(2))
+
+    val res = server.executeQuerySimple(
+      s"""
+         |mutation {
+         |  updateParent(
+         |  where: { p: "p1"}
+         |  data:{
+         |    childrenOpt: {create: [{c: "c3"}]}
+         |  }){
+         |    childrenOpt{
+         |      c
+         |    }
+         |  }
+         |}
+      """.stripMargin,
+      project
+    )
+
+    res.toString should be("""{"data":{"updateParent":{"childrenOpt":[{"c":"c1"},{"c":"c2"},{"c":"c3"}]}}}""")
+
+    server.executeQuerySimple(s"""query{children{c, parentsOpt{p}}}""", project).toString should be(
+      """{"data":{"children":[{"c":"c1","parentsOpt":[{"p":"p1"}]},{"c":"c2","parentsOpt":[{"p":"p1"}]},{"c":"c3","parentsOpt":[{"p":"p1"}]}]}}""")
+
+    database.runDbActionOnClientDb(DatabaseQueryBuilder.itemCountForTable(project.id, "_ChildToParent").as[Int]) should be(Vector(3))
+  }
 
   "a one to many relation" should "be upsertable by id through a nested mutation" in {
     val project = SchemaDsl() { schema =>

--- a/server/api/src/test/scala/com/prisma/api/mutations/OptionalBackrelationSpec.scala
+++ b/server/api/src/test/scala/com/prisma/api/mutations/OptionalBackrelationSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class OptionalBackrelationSpec extends FlatSpec with Matchers with ApiBaseSpec {
 
-  "Nested Update" should "be generated models with missing backrelations " in {
+  "Nested Update" should "be generated for models with missing backrelations " in {
 
     val project = SchemaDsl.fromString() {
       """
@@ -106,6 +106,8 @@ class OptionalBackrelationSpec extends FlatSpec with Matchers with ApiBaseSpec {
         |}""".stripMargin,
       project
     )
+
+    res2.toString should be("""{"data":{"updateOwner":{"ownerName":"jon","cat":{"catName":"azrael"}}}}""")
   }
 
   "Nested Upsert" should "be generated for models with missing backrelations 2 " in {

--- a/server/api/src/test/scala/com/prisma/api/mutations/OptionalBackrelationSpec.scala
+++ b/server/api/src/test/scala/com/prisma/api/mutations/OptionalBackrelationSpec.scala
@@ -1,0 +1,177 @@
+package com.prisma.api.mutations
+
+import com.prisma.api.ApiBaseSpec
+import com.prisma.shared.models.Project
+import com.prisma.shared.schema_dsl.SchemaDsl
+import org.scalatest.{FlatSpec, Matchers}
+
+class OptionalBackrelationSpec extends FlatSpec with Matchers with ApiBaseSpec {
+
+  "Nested Update" should "be generated models with missing backrelations " in {
+
+    val project = SchemaDsl.fromString() {
+      """
+        |type Owner {
+        |  id: ID!
+        |  ownerName: String! @unique
+        |  cat: Cat
+        |}
+        |
+        |type Cat {
+        |  id: ID!
+        |  catName: String! @unique
+        |}
+        |
+      """.stripMargin
+    }
+    database.setup(project)
+
+    createItem(project, "Cat", "garfield")
+    createItem(project, "Owner", "jon")
+
+    //set initial owner
+    val res = server.executeQuerySimple(
+      """mutation {updateOwner(where: {ownerName: "jon"},
+        |data: {cat: {connect: {catName: "garfield"}}}) {
+        |    ownerName
+        |    cat {
+        |      catName
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    val res2 = server.executeQuerySimple(
+      """mutation {updateOwner(where: {ownerName: "jon"},
+        |data: {cat: {update: { where:{catName: "garfield"}, data: {catName: "azrael"}}}}) {
+        |    ownerName
+        |    cat {
+        |      catName
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+  }
+
+  "Nested Upsert" should "be generated models with missing backrelations " in {
+
+    val project = SchemaDsl.fromString() {
+      """
+        |type Owner {
+        |  id: ID!
+        |  ownerName: String! @unique
+        |  cat: Cat
+        |}
+        |
+        |type Cat {
+        |  id: ID!
+        |  catName: String! @unique
+        |}
+        |
+      """.stripMargin
+    }
+    database.setup(project)
+
+    createItem(project, "Cat", "garfield")
+    createItem(project, "Owner", "jon")
+
+    //set initial owner
+    val res = server.executeQuerySimple(
+      """mutation {updateOwner(where: {ownerName: "jon"},
+        |data: {cat: {connect: {catName: "garfield"}}}) {
+        |    ownerName
+        |    cat {
+        |      catName
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    val res2 = server.executeQuerySimple(
+      """mutation {updateOwner(where: {ownerName: "jon"},
+        |data: {cat: {upsert: {
+        |                   where:{catName: "does not exist"},
+        |                   update: {catName: "should not matter"}
+        |                   create: {catName: "azrael"}
+        |                   }}})
+        |{
+        |    ownerName
+        |    cat {
+        |      catName
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+  }
+
+  "Nested Upsert" should "be generated for models with missing backrelations 2 " in {
+
+    val project = SchemaDsl.fromString() {
+      """
+        |type Owner {
+        |  id: ID!
+        |  ownerName: String! @unique
+        |  cat: Cat
+        |}
+        |
+        |type Cat {
+        |  id: ID!
+        |  catName: String! @unique
+        |}
+        |
+      """.stripMargin
+    }
+    database.setup(project)
+
+    createItem(project, "Cat", "garfield")
+    createItem(project, "Owner", "jon")
+
+    //set initial owner
+    val res = server.executeQuerySimple(
+      """mutation {updateOwner(where: {ownerName: "jon"},
+        |data: {cat: {connect: {catName: "garfield"}}}) {
+        |    ownerName
+        |    cat {
+        |      catName
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    val res2 = server.executeQuerySimple(
+      """mutation {updateOwner(where: {ownerName: "jon"},
+        |data: {cat: {upsert: {
+        |                   where:{catName: "garfield"},
+        |                   update: {catName: "azrael"}
+        |                   create: {catName: "should not matter"}
+        |                   }}})
+        |{
+        |    ownerName
+        |    cat {
+        |      catName
+        |    }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    res2.toString should be("""{"data":{"updateOwner":{"ownerName":"jon","cat":{"catName":"azrael"}}}}""")
+  }
+
+  def createItem(project: Project, modelName: String, name: String): Unit = {
+    modelName match {
+      case "Cat"   => server.executeQuerySimple(s"""mutation {createCat(data: {catName: "$name"}){id}}""", project)
+      case "Owner" => server.executeQuerySimple(s"""mutation {createOwner(data: {ownerName: "$name"}){id}}""", project)
+    }
+  }
+
+  def countItems(project: Project, name: String): Int = {
+    server.executeQuerySimple(s"""query{$name{id}}""", project).pathAsSeq(s"data.$name").length
+  }
+
+}

--- a/server/api/src/test/scala/com/prisma/api/schema/MutationsSchemaBuilderSpec.scala
+++ b/server/api/src/test/scala/com/prisma/api/schema/MutationsSchemaBuilderSpec.scala
@@ -229,30 +229,26 @@ class MutationsSchemaBuilderSpec extends FlatSpec with Matchers with ApiBaseSpec
     )
   }
 
-  "the update Mutation for a model with omitted back relation" should "be generated correctly" in {
+  "the update and upsert Mutation for a model with omitted back relation" should "be generated correctly" in {
     val project = SchemaDsl() { schema =>
       val comment = schema.model("Comment").field_!("text", _.String)
-      schema
-        .model("Todo")
-        .field_!("title", _.String)
-        .field("tag", _.String)
-        .oneToManyRelation("comments", "todo", comment, includeFieldB = false)
+      val todo    = schema.model("Todo").field_!("title", _.String).field("tag", _.String)
+      todo.oneToManyRelation("comments", "todo", comment, includeFieldB = false)
     }
 
     val schema = SchemaRenderer.renderSchema(schemaBuilder(project))
-    schema should not(containInputType("CommentCreateWithoutTodoInput"))
-    schema should not(containInputType("CommentUpdateWithoutTodoInput"))
 
-    schema should containInputType("TodoCreateInput",
-                                   fields = Vector(
-                                     "comments: CommentCreateManyInput"
-                                   ))
-
-    schema should containInputType("CommentCreateManyInput",
-                                   fields = Vector(
-                                     "create: [CommentCreateInput!]"
-                                   ))
-
+    schema should containInputType(
+      "CommentUpdateManyInput",
+      fields = Vector(
+        "create: [CommentCreateInput!]",
+        "connect: [CommentWhereUniqueInput!]",
+        "disconnect: [CommentWhereUniqueInput!]",
+        "delete: [CommentWhereUniqueInput!]",
+        "update: [CommentUpdateInput!]",
+        "upsert: [CommentUpsertInput!]"
+      )
+    )
   }
 
   "the upsert Mutation for a model" should "be generated correctly" in {


### PR DESCRIPTION
Fix for https://github.com/graphcool/prisma/issues/1837
- generate the update and upsert input types when there is no backrelation
- adds relation handling for the create case of upsert
- also adds the relay id table entries in the create case of upsert
- add relation test cases for nested upsert in update
