### PR TITLE
UpdateMutation regression

### DIFF
--- a/server/api/src/main/scala/com/prisma/api/schema/InputTypesBuilder.scala
+++ b/server/api/src/main/scala/com/prisma/api/schema/InputTypesBuilder.scala
@@ -101,7 +101,7 @@ abstract class UncachedInputTypesBuilder(project: Project) extends InputTypesBui
     } yield {
       val typeName = omitRelation.getField(project.schema, model) match {
         case Some(field) => s"${model.name}UpdateWithout${field.name.capitalize}Input"
-        case None        => s"${model.name}UpdateInput"
+        case None        => s"${model.name}UpdateNestedInput"
       }
 
       InputObjectType[Any](
@@ -138,7 +138,7 @@ abstract class UncachedInputTypesBuilder(project: Project) extends InputTypesBui
     } yield {
       val typeName = omitRelation.getField(project.schema, model) match {
         case Some(field) => s"${model.name}UpsertWithout${field.name.capitalize}Input"
-        case None        => s"${model.name}UpsertInput"
+        case None        => s"${model.name}UpsertNestedInput"
       }
 
       InputObjectType[Any](
@@ -166,7 +166,6 @@ abstract class UncachedInputTypesBuilder(project: Project) extends InputTypesBui
         InputObjectType[Any](
           name = s"${model.name}WhereUniqueInput",
           fieldsFn = () => {
-
             uniqueFields.map { field =>
               InputField(name = field.name, fieldType = SchemaBuilderUtils.mapToOptionalInputType(field))
             }

--- a/server/api/src/test/scala/com/prisma/api/mutations/UpdateMutationSpec.scala
+++ b/server/api/src/test/scala/com/prisma/api/mutations/UpdateMutationSpec.scala
@@ -200,6 +200,6 @@ class UpdateMutationSpec extends FlatSpec with Matchers with ApiBaseSpec {
     res.toString should be("""{"data":{"updateTodo":{"title":null,"text":"some text"}}}""")
 
     server.executeQuerySimple("""query{todoes{title, text}}""", project).toString should be("""{"data":{"todoes":[{"title":null,"text":"some text"}]}}""")
-
   }
+
 }

--- a/server/api/src/test/scala/com/prisma/api/schema/MutationsSchemaBuilderSpec.scala
+++ b/server/api/src/test/scala/com/prisma/api/schema/MutationsSchemaBuilderSpec.scala
@@ -95,6 +95,55 @@ class MutationsSchemaBuilderSpec extends FlatSpec with Matchers with ApiBaseSpec
                                    ))
   }
 
+  "the update Mutation for a model with a optional backrelation" should "be generated correctly" in {
+    val project = SchemaDsl() { schema =>
+      val list = schema.model("List").field_!("listUnique", _.String, isUnique = true).field("optList", _.String)
+      val todo = schema.model("Todo").field_!("todoUnique", _.String, isUnique = true).field("optString", _.String)
+      list.manyToManyRelation("todoes", "does not matter", todo, includeFieldB = false)
+    }
+
+    val schema = SchemaRenderer.renderSchema(schemaBuilder(project))
+
+    schema should containMutation("updateTodo(data: TodoUpdateInput!, where: TodoWhereUniqueInput!): Todo")
+
+    schema should containInputType("TodoCreateInput",
+                                   fields = Vector(
+                                     "todoUnique: String!",
+                                     "optString: String"
+                                   ))
+
+    schema should containInputType("TodoUpdateInput",
+                                   fields = Vector(
+                                     "todoUnique: String",
+                                     "optString: String"
+                                   ))
+
+    schema should containInputType("TodoUpdateDataInput",
+                                   fields = Vector(
+                                     "todoUnique: String",
+                                     "optString: String"
+                                   ))
+
+    schema should containInputType("TodoWhereUniqueInput",
+                                   fields = Vector(
+                                     "id: ID",
+                                     "todoUnique: String"
+                                   ))
+
+    schema should containInputType("TodoUpdateNestedInput",
+                                   fields = Vector(
+                                     "where: TodoWhereUniqueInput!",
+                                     "data: TodoUpdateDataInput!"
+                                   ))
+
+    schema should containInputType("TodoUpsertNestedInput",
+                                   fields = Vector(
+                                     "where: TodoWhereUniqueInput!",
+                                     "update: TodoUpdateDataInput!",
+                                     "create: TodoCreateInput!"
+                                   ))
+  }
+
   "the update many Mutation for a model" should "be generated correctly" in {
     val project = SchemaDsl() { schema =>
       schema.model("Todo").field_!("title", _.String).field("alias", _.String, isUnique = true)
@@ -245,8 +294,8 @@ class MutationsSchemaBuilderSpec extends FlatSpec with Matchers with ApiBaseSpec
         "connect: [CommentWhereUniqueInput!]",
         "disconnect: [CommentWhereUniqueInput!]",
         "delete: [CommentWhereUniqueInput!]",
-        "update: [CommentUpdateInput!]",
-        "upsert: [CommentUpsertInput!]"
+        "update: [CommentUpdateNestedInput!]",
+        "upsert: [CommentUpsertNestedInput!]"
       )
     )
   }


### PR DESCRIPTION
- rename the InputTypes for models with optional backrelations so that they are unique
- verify schema generation for optional back relations

Fixes https://github.com/graphcool/prisma/issues/1909