### PR TITLE
fix cli contributing docs

### DIFF
--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 $ git clone git@github.com:graphcool/prisma.git
 $ cd prisma/cli
 $ yarn install
+$ cd packages/prisma-yml
+$ yarn install
 $ cd packages/prisma-cli-engine
 $ yarn build
 $ cd ../prisma-cli-core


### PR DESCRIPTION
Small update to `cli/CONTRIBUTING.md` to add a step for installing `prisma-yml` dependencies.

Closes #1932 