### PR TITLE
chore(docs): clarify usage of .env and now

### DIFF
--- a/docs/1.2/03-Tutorials/02-GraphQL-Server-Development/01-Deployment-with-Now.md
+++ b/docs/1.2/03-Tutorials/02-GraphQL-Server-Development/01-Deployment-with-Now.md
@@ -112,8 +112,10 @@ All you need to is navigate into the `hello-advanced` directory and invoke `now`
 
 ```
 cd hello-advanced
-now --dotenv
+now --dotenv .env
 ```
+
+> Note: you may obmit the path to the `.env` file since `now` by default uses a file named `.env`.
 
 </Instruction>
 

--- a/docs/1.2/03-Tutorials/02-GraphQL-Server-Development/01-Deployment-with-Now.md
+++ b/docs/1.2/03-Tutorials/02-GraphQL-Server-Development/01-Deployment-with-Now.md
@@ -112,15 +112,15 @@ All you need to is navigate into the `hello-advanced` directory and invoke `now`
 
 ```
 cd hello-advanced
-now --dotenv .env
+now --dotenv
 ```
 
 </Instruction>
 
-If you deployed your Prisma service locally with Docker, your `.env` file will contain local references for the environment variables `PRISMA_ENDPOINT` and `PRISMA_CLUSTER` (such as `http://localhost:60000/hello-advanced/dev`). In that case you can create another `.env` file (e.g. called `.env.prod`) and make the `PRISMA_ENDPOINT` and `PRISMA_CLUSTER` are set to proper remote URLs (of course that requires that you properly deploy the Prisma service to some public cluster on the web before)  and then refer to that one during deployment:
+If you deployed your Prisma service locally with Docker, your `.env` file will contain local references for the environment variables `PRISMA_ENDPOINT` and `PRISMA_CLUSTER` (such as `http://localhost:60000/hello-advanced/dev`). In that case you can create another `.env` file (e.g. called `.env.prod`) and make sure the `PRISMA_ENDPOINT` and `PRISMA_CLUSTER` are set to proper remote URLs (of course that requires that you properly deploy the Prisma service to some public cluster on the web before)  and then refer to that one during deployment:
 
 ```sh
-now --dotenv .env
+now --dotenv .env.prod
 ```
 
 You can find some documentation about how to handle environment variables and secrets when using `now` [here](https://zeit.co/docs/features/env-and-secrets).


### PR DESCRIPTION
The `now --dotenv` flag by default uses the file `.env`, so I removed the explicit mentioning of this file.
The example regarding "production" was pointing to the wrong `.env` instead of `.env.prod`.