### PR TITLE
fix: remove trailing slash from configured `baseUrl`

### DIFF
--- a/cli/packages/prisma-yml/src/Cluster.ts
+++ b/cli/packages/prisma-yml/src/Cluster.ts
@@ -30,7 +30,12 @@ export class Cluster {
   ) {
     this.out = out
     this.name = name
-    this.baseUrl = baseUrl
+
+    // All `baseUrl` extension points in this class
+    // adds a trailing slash. Here we remove it from
+    // the passed `baseUrl` in order to avoid double
+    // slashes.
+    this.baseUrl = baseUrl.replace(/\/$/, "")
     this.clusterSecret = clusterSecret
     this.local = local
     this.shared = shared


### PR DESCRIPTION
This PR proposes to sanitize the `baseUrl` by removing a possible trailing slash.

Reference: https://github.com/graphcool/prisma/issues/1955