### PR TITLE
Fix incorrect message when stopping local cluster

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/local/stop.ts
+++ b/cli/packages/prisma-cli-core/src/commands/local/stop.ts
@@ -16,7 +16,7 @@ export default class Stop extends Command {
   }
   async run() {
     const docker = new Docker(this.out, this.config, this.env, this.flags.name)
-    this.out.action.start('Booting local development cluster')
+    this.out.action.start('Stopping local development cluster')
     const before = Date.now()
     await docker.stop()
     this.out.action.stop(prettyTime(Date.now() - before))


### PR DESCRIPTION
It's rather confusing when you tell the cluster to stop and get greeted with `Booting local development cluster`.

This PR simply changes it to `Stopping local development cluster`