### PR TITLE
Update 01-Overview-&-Example.md

### DIFF
--- a/docs/1.3/04-Reference/02-Service-Configuration/02-prisma.yml/01-Overview-&-Example.md
+++ b/docs/1.3/04-Reference/02-Service-Configuration/02-prisma.yml/01-Overview-&-Example.md
@@ -83,10 +83,35 @@ This service definition expects the following file structure:
 .
 ├── prisma.yml
 ├── database
-│   ├── subscriptions
-│   │   └── welcomeEmail.graphql
-│   ├── types.graphql
-│   └── enums.graphql
+│   ├── subscriptions
+│   │   └── welcomeEmail.graphql
+│   ├── types.graphql
+│   └── enums.graphql
 └── schemas
-    └── prisma.graphql
+    └── prisma.graphql
 ```
+
+## Tooling integrations
+
+### Get autocompletion and validation while configuring `prisma.yml`
+
+If you wish to have autocompletion while configuring your `prisma.yml` configuration file, as well as static errors checking before deploying your service, a [JSON Schema](https://github.com/graphcool/prisma-json-schema) is available to provide this kind of experience.
+**For now though, it is only available for [VSCode](https://code.visualstudio.com/).**
+
+
+**Step 1.**
+
+Download and install [vs-code-yaml by redhat](https://github.com/redhat-developer/vscode-yaml) plugin.
+
+**Step 2.**
+
+Add the following to the [user and workspace settings](https://code.visualstudio.com/docs/getstarted/settings#_creating-user-and-workspace-settings):
+
+```
+"yaml.schemas": {
+  "http://json.schemastore.org/prisma": "prisma.yml"
+}
+```
+**Step 3.**
+
+Trigger the intellisense using your usual hotkey (*Ctrl + Space* by default) on your `prisma.yml` file. It should now display all the available fields, along with their descriptions. If any errors are made, VSCode will instantly catch them.


### PR DESCRIPTION
Added documentation for VSCode developers to use JSON Schema autocompletion/validation directly within their IDE when configuring their `prisma.yml` configuration file.

Not sure why the tree structure is diffing, I haven't touched it.