### PR TITLE
Standardize the error format to be valid GraphQL

### DIFF
--- a/server/api/src/main/scala/com/prisma/api/schema/Errors.scala
+++ b/server/api/src/main/scala/com/prisma/api/schema/Errors.scala
@@ -5,7 +5,7 @@ import com.prisma.api.mutations.NodeSelector
 import com.prisma.api.mutations.mutations.CascadingDeletes.{ModelEdge, NodeEdge, Path}
 import com.prisma.sangria.utils.ErrorWithCode
 import com.prisma.shared.models.{Project, Relation}
-import spray.json.JsValue
+import spray.json.{JsArray, JsNumber, JsObject, JsString, JsValue}
 
 abstract class GeneralError(message: String) extends Exception with MutactionExecutionResult with ErrorWithCode {
   override def getMessage: String = message
@@ -67,7 +67,7 @@ object APIErrors {
       )
 
   case class InvalidToken()
-      extends ClientApiError(s"Your token is invalid. It might have expired or you might be using a token from a different project.", 3015)
+      extends ClientApiError(s" Your token is invalid. It might have expired or you might be using a token from a different project.", 3015)
 
   case class ProjectNotFound(projectId: String) extends ClientApiError(s"Project not found: '$projectId'", 3016)
 
@@ -159,4 +159,9 @@ object APIErrors {
     }
   }
 
+  def errorJson(requestId: String, message: String, errorCode: Int): JsObject = errorJson(requestId, message, Some(errorCode))
+  def errorJson(requestId: String, message: String, errorCode: Option[Int] = None): JsObject = errorCode match {
+    case None       => JsObject("errors" -> JsArray(JsObject("message" -> JsString(message), "requestId" -> JsString(requestId))))
+    case Some(code) => JsObject("errors" -> JsArray(JsObject("message" -> JsString(message), "code"      -> JsNumber(code), "requestId" -> JsString(requestId))))
+  }
 }

--- a/server/api/src/main/scala/com/prisma/api/server/RequestHandler.scala
+++ b/server/api/src/main/scala/com/prisma/api/server/RequestHandler.scala
@@ -13,8 +13,9 @@ import com.prisma.auth.Auth
 import com.prisma.client.server.GraphQlRequestHandler
 import com.prisma.shared.models.{Project, ProjectWithClientId}
 import com.prisma.utils.`try`.TryExtensions._
+import io.netty.channel.unix.Errors
 import sangria.schema.Schema
-import spray.json.{JsObject, JsString, JsValue}
+import spray.json.{JsArray, JsNumber, JsObject, JsString, JsValue}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Failure
@@ -49,7 +50,7 @@ case class RequestHandler(
         result         <- handleGraphQlRequest(graphQlRequest)
       } yield result
     }.recoverWith {
-      case e: InvalidGraphQlRequest => Future.successful(OK -> JsObject("error" -> JsString(e.underlying.getMessage)))
+      case e: InvalidGraphQlRequest => Future.successful(OK -> APIErrors.errorJson(rawRequest.id, e.underlying.getMessage))
     }
   }
 
@@ -103,4 +104,5 @@ case class RequestHandler(
       case Some(schema) => schema
     }
   }
+
 }

--- a/server/api/src/test/scala/com/prisma/api/server/RequestHandlerSpec.scala
+++ b/server/api/src/test/scala/com/prisma/api/server/RequestHandlerSpec.scala
@@ -13,7 +13,7 @@ import com.prisma.utils.await.AwaitUtils
 import org.scalatest.{FlatSpec, Matchers}
 import pdi.jwt.{Jwt, JwtAlgorithm}
 import sangria.schema.{ObjectType, Schema, SchemaValidationRule}
-import spray.json.JsObject
+import spray.json.{JsObject, JsString}
 
 import scala.concurrent.Future
 
@@ -34,7 +34,8 @@ class RequestHandlerSpec extends FlatSpec with Matchers with ApiBaseSpec with Aw
 
   val projectWithSecret = TestProject().copy(secrets = Vector("secret"))
 
-  def request(authHeader: String) = RawRequest(id = "req-id", json = JsObject(), ip = "0.0.0.0", sourceHeader = null, authorizationHeader = Some(authHeader))
+  def request(authHeader: String) =
+    RawRequest(id = "req-id", json = JsObject("query" -> JsString("{users}")), ip = "0.0.0.0", sourceHeader = null, authorizationHeader = Some(authHeader))
 
   def handler(project: Project) = {
     RequestHandler(

--- a/server/libs/sangria-utils/src/main/scala/com/prisma/sangria/utils/ErrorHandler.scala
+++ b/server/libs/sangria-utils/src/main/scala/com/prisma/sangria/utils/ErrorHandler.scala
@@ -37,9 +37,7 @@ case class ErrorHandler(
       HandledException(internalErrorMessage, commonFields(marshaller))
   }
 
-  lazy val sangriaExceptionHandler: Executor.ExceptionHandler = sangria.execution.ExceptionHandler(
-    onException = handler
-  )
+  lazy val sangriaExceptionHandler: Executor.ExceptionHandler = sangria.execution.ExceptionHandler(onException = handler)
 
   private def commonFields(marshaller: ResultMarshaller) = Map(
     "requestId" -> marshaller.scalarNode(requestId, "Int", Set.empty)


### PR DESCRIPTION
always return  a valid GraphQL error of the shape: '"errors": ["message": "...", "requestId": "..."]' 