### PR TITLE
Minor Update Doc - Remove `Bearer` prefix on Authorization

### DIFF
--- a/docs/1.3/04-Reference/03-Prisma-API/02-Concepts.md
+++ b/docs/1.3/04-Reference/03-Prisma-API/02-Concepts.md
@@ -197,7 +197,7 @@ The GraphQL API of a Prisma service is typically protected by a [service secret]
 The `secret` is used to sign a [JWT](https://jwt.io/) which can then be used in the `Authorization` field of the HTTP header:
 
 ```
-Authorization: Bearer __TOKEN__
+Authorization: __TOKEN__
 ```
 
 This is a sample payload for a JWT:

--- a/docs/1.3/04-Reference/06-Data-Import-&-Export/01-Data-Import.md
+++ b/docs/1.3/04-Reference/06-Data-Import-&-Export/01-Data-Import.md
@@ -112,7 +112,7 @@ Here is an example `curl` command for uploading some JSON data (of NDF type `nod
 ```sh
 curl 'http://localhost:60000/my-app/dev/import' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MTM1OTQzMTEsImV4cCI6MTU0NTEzMDMxMSwiYXVkIjasd3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.L7DwH7vIfTSmuwfxBI82D64DlgoLBLXOwR5iMjZ_7nI' \
+-H 'Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MTM1OTQzMTEsImV4cCI6MTU0NTEzMDMxMSwiYXVkIjasd3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.L7DwH7vIfTSmuwfxBI82D64DlgoLBLXOwR5iMjZ_7nI' \
 -d '{"valueType":"nodes","values":[{"_typeName":"Model0","id":"0","a":"test","b":0,"createdAt":"2017-11-29 14:35:13"},{"_typeName":"Model1","id":"1","a":"test","b":1},{"_typeName":"Model2","id":"2","a":"test","b":2,"createdAt":"2017-11-29 14:35:13"},{"_typeName":"Model0","id":"3","a":"test","b":3},{"_typeName":"Model3","id":"4","a":"test","b":4,"createdAt":"2017-11-29 14:35:13","updatedAt":"2017-11-29 14:35:13"},{"_typeName":"Model3","id":"5","a":"test","b":5},{"_typeName":"Model3","id":"6","a":"test","b":6},{"_typeName":"Model4","id":"7"},{"_typeName":"Model4","id":"8","string":"test","int":4,"boolean":true,"dateTime":"1015-11-29 14:35:13","float":13.333,"createdAt":"2017-11-29 14:35:13","updatedAt":"2017-11-29 14:35:13"},{"_typeName":"Model5","id":"9","string":"test","int":4,"boolean":true,"dateTime":"1015-11-29 14:35:13","float":13.333,"createdAt":"2017-11-29 14:35:13","updatedAt":"2017-11-29 14:35:13"}]}' \
 -sSv
 ```
@@ -122,7 +122,7 @@ The generic version for `curl` (using placeholders) would look as follows:
 ```sh
 curl '__SERVICE_ENDPOINT__/import' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Bearer __JWT_AUTH_TOKEN__' \
+-H 'Authorization: __JWT_AUTH_TOKEN__' \
 -d '{"valueType":"__NDF_TYPE__","values": __DATA__ }' \
 -sSv
 ```

--- a/docs/1.3/04-Reference/06-Data-Import-&-Export/02-Data-Export.md
+++ b/docs/1.3/04-Reference/06-Data-Import-&-Export/02-Data-Export.md
@@ -58,7 +58,7 @@ Here is an example `curl` command for uploading some JSON data (of NDF type `nod
 ```sh
 curl 'http://localhost:60000/my-app/dev/export' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MTM1OTQzMTEsImV4cCI6MTU0NTEzMDMxMSwiYXVkIjasd3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.L7DwH7vIfTSmuwfxBI82D64DlgoLBLXOwR5iMjZ_7nI' \
+-H 'Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MTM1OTQzMTEsImV4cCI6MTU0NTEzMDMxMSwiYXVkIjasd3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.L7DwH7vIfTSmuwfxBI82D64DlgoLBLXOwR5iMjZ_7nI' \
 -d '{"fileType":"nodes","cursor":{"table":0,"row":0,"field":0,"array":0}}' \
 -sSv
 ```
@@ -68,7 +68,7 @@ The generic version for `curl` (using placeholders) would look as follows:
 ```sh
 curl '__SERVICE_ENDPOINT__/export' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Bearer __JWT_AUTH_TOKEN__' \
+-H 'Authorization: __JWT_AUTH_TOKEN__' \
 -d '{"fileType":"__NDF_TYPE__","cursor": {"table":__TABLE__,"row":__ROW__,"field":__FIELD__,"array":__ARRAY__}} }' \
 -sSv
 ```


### PR DESCRIPTION
## Update Documentation

- Remove `Bearer` prefix on Authorization (HTTP Header)

## Note

- I've tried to import/export data via `curl` on Prisma v 1.3.5 with `Bearer` prefix and without it and It work both. I've choiced the second one for the docs.

-  Some pages on Graphql Ecosystem (e.g. Graphql Config, Graphql Request) were not updated. I suppose these packages can be used with general graphql server. Not only Prisma.

: )