### PR TITLE
Metrics health check and recovery

### DIFF
--- a/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdMain.scala
+++ b/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdMain.scala
@@ -6,9 +6,9 @@ import com.prisma.akkautil.http.ServerExecutor
 import com.prisma.api.server.ApiServer
 import com.prisma.deploy.server.ClusterServer
 import com.prisma.subscriptions.SimpleSubscriptionsServer
+import com.prisma.utils.boolean.BooleanUtils._
 import com.prisma.websocket.WebsocketServer
 import com.prisma.workers.WorkerServer
-import com.prisma.utils.boolean.BooleanUtils._
 
 object PrismaProdMain extends App {
   implicit val system       = ActorSystem("single-server")

--- a/server/libs/metrics/src/main/scala/com/prisma/metrics/MetricsManager.scala
+++ b/server/libs/metrics/src/main/scala/com/prisma/metrics/MetricsManager.scala
@@ -12,26 +12,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-/**
-  * Metrics management, should be inherited and instantiated _once per logical service_.
-  *
-  * The metrics structure reported from this code to the statsd backend is as follows:
-  *
-  * {service_name}.{metric_name}#env={env}container={container_id},instance={instance_id}[,{custom_tag}={custom_value}]
-  *
-  * - The basic metrics name that goes to statsd is simply the logical service name plus the metric name, e.g. "ApiSimpleService.OpenSessions"
-  * - After that, there is a series of tags:
-  *   - The env var "METRICS_PREFIX" is used to denote the env the service is running in, e.g. 'dev' or 'prod'.
-  *   - The EC2 instance this code is run from. Fetched from EC2
-  *   - The container ID this code is run from. Fetched from /etc/hostname, as it is identical to the container ID in ECS.
-  *   - Custom metric tags. These should be used sparsely and only if it delivers crucial insights, such as per-project distinctions.
-  *
-  * The final metric that arrives at Statsd looks for example like this:
-  * "ApiSimpleService.RequestCount#env=prod,instance=i-0d3c23cdd0c2f5d03,container=e065fc831976,projectId=someCUID
-  */
-abstract class MetricsManager(
-    reporter: ErrorReporter
-) {
+abstract class MetricsManager(reporter: ErrorReporter) {
   def serviceName: String
 
   // System used to periodically flush the state of individual gauges

--- a/server/libs/metrics/src/main/scala/com/prisma/metrics/MetricsManager.scala
+++ b/server/libs/metrics/src/main/scala/com/prisma/metrics/MetricsManager.scala
@@ -49,14 +49,13 @@ abstract class MetricsManager(reporter: ErrorReporter) {
 
   protected val client: StatsDClient = {
     if (metricsCollectionIsEnabled) {
-      val dnsNameOpt         = sys.env.get("STATSD_DNS_NAME")
-      val portOpt            = Utils.envVarAsInt("STATSD_PORT")
-      val isReachableTimeout = Utils.envVarAsInt("STATSD_REACHABLE_TIMEOUT").getOrElse(500)
+      val dnsNameOpt = sys.env.get("STATSD_DNS_NAME")
+      val portOpt    = Utils.envVarAsInt("STATSD_PORT")
 
       (dnsNameOpt, portOpt) match {
         case (Some(dnsName), Some(port)) =>
           log(s"Will report metrics to $dnsName on port $port")
-          new NonBlockingStatsDClient("", Integer.MAX_VALUE, new Array[String](0), errorHandler, StatsdHostLookup(dnsName, port, isReachableTimeout))
+          new NonBlockingStatsDClient("", Integer.MAX_VALUE, new Array[String](0), errorHandler, StatsdHostLookup(dnsName, port))
 
         case _ =>
           log("Warning: no metrics will be recorded. The env vars STATSD_DNS_NAME and STATSD_PORT must be set.")

--- a/server/libs/metrics/src/main/scala/com/prisma/metrics/StatsdHealthChecker.scala
+++ b/server/libs/metrics/src/main/scala/com/prisma/metrics/StatsdHealthChecker.scala
@@ -1,0 +1,73 @@
+package com.prisma.metrics
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import akka.actor.{Actor, Props, Timers}
+import akka.pattern.ask
+import akka.stream.ActorMaterializer
+import akka.util.Timeout
+import com.prisma.akkautil.SingleThreadedActorSystem
+import com.prisma.akkautil.http.SimpleHttpClient
+
+import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success}
+import scala.concurrent.duration._
+
+case class StatsdHealthChecker() {
+  import StatsdHealthCheckerActor._
+  import system.dispatcher
+
+  implicit val system       = SingleThreadedActorSystem("statsd-health")
+  implicit val materializer = ActorMaterializer()
+  implicit val timeout      = new Timeout(5.minutes)
+
+  val httpClient = SimpleHttpClient()
+  val actor      = system.actorOf(Props(StatsdHealthCheckerActor(httpClient)))
+
+  def isUp: Boolean =
+    Await.result((actor ? Status).mapTo[Boolean].transformWith {
+      case Success(bool) => Future.successful(bool)
+      case Failure(e)    => Future.successful(false)
+    }, 2.seconds)
+
+  def newIP(ip: String) = actor ! NewIP(ip)
+}
+
+object StatsdHealthCheckerActor {
+  case object TickKey
+  case object Init
+  case object Check
+  case object Status
+  case class NewIP(ip: String)
+}
+
+case class StatsdHealthCheckerActor(httpClient: SimpleHttpClient) extends Actor with Timers {
+  import StatsdHealthCheckerActor._
+
+  implicit val ec = context.system.dispatcher
+
+  private var ipToCheck  = ""
+  private val statsdIsUp = new AtomicBoolean(true)
+  private val port       = sys.env.getOrElse("METRICS_HEALTH_PORT", sys.error("METRICS_HEALTH_PORT env var required but not found."))
+
+  def receive = {
+    case Check =>
+      checkAndWriteHealthStatus()
+
+    case NewIP(ip) =>
+      ipToCheck = ip
+      timers.cancel(TickKey)
+      checkAndWriteHealthStatus()
+      timers.startPeriodicTimer(TickKey, Check, 5.seconds) // Check health every 5 seconds
+
+    case Status =>
+      sender ! statsdIsUp
+  }
+
+  private def checkAndWriteHealthStatus() = {
+    httpClient.get(s"http://$ipToCheck:$port", timeout = 2.seconds).onComplete {
+      case Success(resp) => statsdIsUp.set(true)
+      case Failure(e)    => statsdIsUp.set(false)
+    }
+  }
+}

--- a/server/libs/metrics/src/main/scala/com/prisma/metrics/StatsdHealthChecker.scala
+++ b/server/libs/metrics/src/main/scala/com/prisma/metrics/StatsdHealthChecker.scala
@@ -47,7 +47,7 @@ case class StatsdHealthCheckerActor(httpClient: SimpleHttpClient) extends Actor 
   implicit val ec = context.system.dispatcher
 
   private var ipToCheck  = ""
-  private val statsdIsUp = new AtomicBoolean(true)
+  private var statsdIsUp = new AtomicBoolean(true)
   private val port       = sys.env.getOrElse("METRICS_HEALTH_PORT", sys.error("METRICS_HEALTH_PORT env var required but not found."))
 
   def receive = {
@@ -61,11 +61,11 @@ case class StatsdHealthCheckerActor(httpClient: SimpleHttpClient) extends Actor 
       timers.startPeriodicTimer(TickKey, Check, 5.seconds) // Check health every 5 seconds
 
     case Status =>
-      sender ! statsdIsUp
+      sender ! statsdIsUp.get()
   }
 
   private def checkAndWriteHealthStatus() = {
-    httpClient.get(s"http://$ipToCheck:$port", timeout = 2.seconds).onComplete {
+    httpClient.get(s"http://$ipToCheck:$port/status", timeout = 2.seconds).onComplete {
       case Success(resp) => statsdIsUp.set(true)
       case Failure(e)    => statsdIsUp.set(false)
     }

--- a/server/libs/metrics/src/main/scala/com/prisma/metrics/StatsdHostLookup.scala
+++ b/server/libs/metrics/src/main/scala/com/prisma/metrics/StatsdHostLookup.scala
@@ -1,10 +1,7 @@
 package com.prisma.metrics
 
-import java.net.{DatagramSocket, InetAddress, InetSocketAddress, Socket}
+import java.net.{InetAddress, InetSocketAddress}
 import java.util.concurrent.Callable
-
-import scala.concurrent.Await
-import scala.util.{Failure, Success, Try}
 
 /**
   * As soon as metrics are flushed, this callable is evaluated.
@@ -16,8 +13,8 @@ import scala.util.{Failure, Success, Try}
   * - Metrics are queued inmemory (defined in the client), nothing is lost on error here.
   */
 case class StatsdHostLookup(dnsName: String, port: Int, reachableTimeout: Int) extends Callable[InetSocketAddress] {
-
   var lookupCache: Option[InetSocketAddress] = None
+  val healthChecker                          = StatsdHealthChecker()
 
   override def call(): InetSocketAddress = {
     lookupCache match {
@@ -25,44 +22,24 @@ case class StatsdHostLookup(dnsName: String, port: Int, reachableTimeout: Int) e
         resolveAndPutIntoCache()
 
       case Some(inetSocketAddr) =>
-//        val isReachable = doesServerListenOnSocketAddress(inetSocketAddr)
-//        if (isReachable) {
-//          log(s"isReachable: ${pretty(inetSocketAddr)}")
-//          inetSocketAddr
-//        } else {
-//          log(s"socket address was not reachable anymore")
-//          resolveAndPutIntoCache()
-//        }
-        inetSocketAddr
+        if (healthChecker.isUp) {
+          inetSocketAddr
+        } else {
+          resolveAndPutIntoCache()
+        }
     }
   }
 
   def resolveAndPutIntoCache(): InetSocketAddress = {
     val address       = InetAddress.getByName(dnsName)
     val socketAddress = new InetSocketAddress(address, port)
-    log(s"resolved: ${pretty(socketAddress)}")
+
+    log(s"Resolved:s ${pretty(socketAddress)}")
+    healthChecker.newIP(address.getHostAddress)
     lookupCache = Some(socketAddress)
     socketAddress
   }
 
   def pretty(socketAddress: InetSocketAddress) = s"IP:${socketAddress.getAddress.getHostAddress} Port:${socketAddress.getPort}"
-
-//  def doesServerListenOnSocketAddress(socketAddress: InetSocketAddress): Boolean = {
-//    Try {
-//      val socket = new DatagramSocket()
-//      socket.connect(socketAddress)
-//      socket
-//    } match {
-//      case Success(socket) =>
-//        Try(socket.close())
-//        true
-//
-//      case Failure(exception) =>
-//        log(s"failed with the following exception")
-//        exception.printStackTrace()
-//        false
-//    }
-//  }
-
-  def log(msg: String): Unit = println(s"[${this.getClass.getSimpleName}] $msg")
+  def log(msg: String): Unit                   = println(s"[${this.getClass.getSimpleName}] $msg")
 }

--- a/server/libs/metrics/src/main/scala/com/prisma/metrics/StatsdHostLookup.scala
+++ b/server/libs/metrics/src/main/scala/com/prisma/metrics/StatsdHostLookup.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.Callable
   * - This catches transient network errors in resolving the statsd host.
   * - Metrics are queued inmemory (defined in the client), nothing is lost on error here.
   */
-case class StatsdHostLookup(dnsName: String, port: Int, reachableTimeout: Int) extends Callable[InetSocketAddress] {
+case class StatsdHostLookup(dnsName: String, port: Int) extends Callable[InetSocketAddress] {
   var lookupCache: Option[InetSocketAddress] = None
   val healthChecker                          = StatsdHealthChecker()
 


### PR DESCRIPTION
- Allows the metrics implementation to periodically check the health of the picked statsd buddy instance.
- Automatically fails over to another available statsd instance in case a health check fails.