### PR TITLE
Added non-interactive mode for `cluster add`

### DIFF
--- a/docs/1.4/04-Reference/07-CLI-Command-Reference/05-Clusters/03-prisma-cluster-add.md
+++ b/docs/1.4/04-Reference/07-CLI-Command-Reference/05-Clusters/03-prisma-cluster-add.md
@@ -5,10 +5,32 @@ description: Add an existing cluster.
 
 # `prisma cluster add`
 
-Add a new cluster to the [cluster registry](!alias-eu2ood0she#cluster-regsitry). This command triggers an interactive prompt where you need to provide the _name_, `host` and `clusterSecret` for the new cluster. 
+Add a new cluster to the [cluster registry](!alias-eu2ood0she#cluster-regsitry).
 
 #### Usage
 
 ```sh
 prisma cluster add
+```
+
+#### Flags
+
+```
+ -n, --name NAME            Cluster name
+ -e, --endpoint ENDPOINT    Cluster endpoint
+ -s, --secret SECRET        Cluster secret (optional)
+```
+
+#### Examples
+
+##### For interactive usage execute command without flags.
+
+```sh
+prisma cluster add
+```
+
+##### For non-interactive usage execute command with flags --name, --endpoint and optional --secret.
+
+```sh
+prisma cluster add --name <cluster name> --endpoint <cluster host> --secret <cluster secret>
 ```


### PR DESCRIPTION
I added possibility to using `cluster add` in non-interactive mode to using command by CI/CD. Please review and merge. 

Ref #1919 #2131 #1948 

