### PR TITLE
Update throttling to akka 2.5.x streams

### DIFF
--- a/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
@@ -57,8 +57,8 @@ case class ApiServer(
     } yield {
       val per = EnvUtils.asInt("THROTTLING_RATE_PER_SECONDS").getOrElse(1)
       Throttler[ProjectId](
-        groupBy = pid => pid.name + "_" + pid.stage,
-        amount = throttlingRate.toInt,
+        groupBy = pid => pid.name + "~" + pid.stage,
+        amount = throttlingRate,
         per = per.seconds,
         timeout = 25.seconds,
         maxCallsInFlight = maxCallsInFlights.toInt


### PR DESCRIPTION
This additionally fixes throttling rates not being applied correctly, currently the case for prisma demo clusters.