### PR TITLE
Change isolation level to Read Committed

### DIFF
--- a/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/database/DatabaseMutationBuilder.scala
+++ b/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/database/DatabaseMutationBuilder.scala
@@ -227,13 +227,14 @@ object DatabaseMutationBuilder {
   // region HELPERS
 
   def idFromWhere(projectId: String, where: NodeSelector): SQLActionBuilder = {
-    sql"(SELECT `id` FROM (SELECT * FROM `#$projectId`.`#${where.model.name}`) IDFROMWHERE WHERE `#${where.field.name}` = ${where.fieldValue})"
+    if (where.isId) {
+      sql"${where.fieldValue}"
+    } else {
+      sql"(SELECT `id` FROM (SELECT * FROM `#$projectId`.`#${where.model.name}`) IDFROMWHERE WHERE `#${where.field.name}` = ${where.fieldValue})"
+    }
   }
 
-  def idFromWhereEquals(projectId: String, where: NodeSelector): SQLActionBuilder = where.isId match {
-    case true  => sql" = ${where.fieldValue}"
-    case false => sql" = " ++ idFromWhere(projectId, where)
-  }
+  def idFromWhereEquals(projectId: String, where: NodeSelector): SQLActionBuilder = sql" = " ++ idFromWhere(projectId, where)
 
   def idFromWherePath(projectId: String, where: NodeSelector): SQLActionBuilder = {
     sql"(SELECT `id` FROM (SELECT  * From `#$projectId`.`#${where.model.name}`) IDFROMWHEREPATH WHERE `#${where.field.name}` = ${where.fieldValue})"

--- a/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/database/DatabaseMutationBuilder.scala
+++ b/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/database/DatabaseMutationBuilder.scala
@@ -174,8 +174,9 @@ object DatabaseMutationBuilder {
   }
 
   def cascadingDeleteChildActions(projectId: String, path: Path) = {
-    val deleteRelayIds  = (sql"DELETE FROM `#$projectId`.`_RelayId` WHERE `id` IN " ++ pathQueryForLastChild(projectId, path)).asUpdate
-    val deleteDataItems = (sql"DELETE FROM `#$projectId`.`#${path.lastModel.name}` WHERE `id` IN " ++ pathQueryForLastChild(projectId, path)).asUpdate
+    val deleteRelayIds = (sql"DELETE FROM `#$projectId`.`_RelayId` WHERE `id` IN (" ++ pathQueryForLastChild(projectId, path) ++ sql")").asUpdate
+    val deleteDataItems =
+      (sql"DELETE FROM `#$projectId`.`#${path.lastModel.name}` WHERE `id` IN (" ++ pathQueryForLastChild(projectId, path) ++ sql")").asUpdate
     DBIO.seq(deleteRelayIds, deleteDataItems)
   }
 
@@ -267,7 +268,7 @@ object DatabaseMutationBuilder {
 
         sql"(SELECT `#${last.childRelationSide}`" ++
           sql" FROM (SELECT * FROM `#$projectId`.`#${last.relation.id}`) PATHQUERY" ++
-          sql" WHERE " ++ childWhere ++ sql"`#${last.parentRelationSide}` IN " ++ pathQueryForLastParent(projectId, path) ++ sql")"
+          sql" WHERE " ++ childWhere ++ sql"`#${last.parentRelationSide}` IN (" ++ pathQueryForLastParent(projectId, path) ++ sql"))"
     }
   }
 
@@ -302,17 +303,17 @@ object DatabaseMutationBuilder {
 
   def oldParentFailureTrigger(project: Project, path: Path) = {
     val table = path.lastRelation_!.id
-    val query = sql"SELECT `id` FROM `#${project.id}`.`#$table` OLDPARENTPATHFAILURETRIGGER WHERE `#${path.childSideOfLastEdge}` IN " ++ pathQueryForLastChild(
+    val query = sql"SELECT `id` FROM `#${project.id}`.`#$table` OLDPARENTPATHFAILURETRIGGER WHERE `#${path.childSideOfLastEdge}` IN (" ++ pathQueryForLastChild(
       project.id,
-      path)
+      path) ++ sql")"
     triggerFailureWhenExists(project, query, table)
   }
 
   def oldParentFailureTriggerByField(project: Project, path: Path, field: Field) = {
     val table = field.relation.get.id
-    val query = sql"SELECT `id` FROM `#${project.id}`.`#$table` OLDPARENTPATHFAILURETRIGGERBYFIELD WHERE `#${field.oppositeRelationSide.get}` IN " ++ pathQueryForLastChild(
+    val query = sql"SELECT `id` FROM `#${project.id}`.`#$table` OLDPARENTPATHFAILURETRIGGERBYFIELD WHERE `#${field.oppositeRelationSide.get}` IN (" ++ pathQueryForLastChild(
       project.id,
-      path)
+      path) ++ sql")"
     triggerFailureWhenExists(project, query, table)
   }
 
@@ -329,9 +330,9 @@ object DatabaseMutationBuilder {
 
   def oldChildFailureTrigger(project: Project, path: Path) = {
     val table = path.lastRelation_!.id
-    val query = sql"SELECT `id` FROM `#${project.id}`.`#$table` OLDCHILDPATHFAILURETRIGGER WHERE `#${path.parentSideOfLastEdge}` IN " ++ pathQueryForLastParent(
+    val query = sql"SELECT `id` FROM `#${project.id}`.`#$table` OLDCHILDPATHFAILURETRIGGER WHERE `#${path.parentSideOfLastEdge}` IN (" ++ pathQueryForLastParent(
       project.id,
-      path)
+      path) ++ sql")"
     triggerFailureWhenExists(project, query, table)
   }
 

--- a/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/database/DatabaseQueryBuilder.scala
+++ b/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/database/DatabaseQueryBuilder.scala
@@ -291,7 +291,11 @@ object DatabaseQueryBuilder {
   }
 
   def existsByPath(projectId: String, path: Path) = {
-    sql"select exists" ++ DatabaseMutationBuilder.pathQueryForLastChild(projectId, path)
+    if (path.edges.isEmpty && path.root.isId) {
+      sql"select exists (SELECT * FROM `#$projectId`.`#${path.root.model.name}` WHERE `id` = ${path.root.fieldValue})"
+    } else {
+      sql"select exists" ++ DatabaseMutationBuilder.pathQueryForLastChild(projectId, path)
+    }
   }
 
   def selectFromScalarList(projectId: String, modelName: String, fieldName: String, nodeIds: Vector[String]): SQLActionBuilder = {

--- a/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/impl/DatabaseMutactionExecutorImpl.scala
+++ b/server/connectors/api-connector-mysql/src/main/scala/com/prisma/api/connector/mysql/impl/DatabaseMutactionExecutorImpl.scala
@@ -3,6 +3,7 @@ package com.prisma.api.connector.mysql.impl
 import com.prisma.api.connector.mysql.DatabaseMutactionInterpreter
 import com.prisma.api.connector._
 import slick.jdbc.MySQLProfile.api._
+import slick.jdbc.TransactionIsolation
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -20,7 +21,7 @@ case class DatabaseMutactionExecutorImpl(
       case false => DBIO.seq(interpreters.map(_.action): _*)
     }
     clientDb
-      .run(singleAction)
+      .run(singleAction.withTransactionIsolation(TransactionIsolation.ReadCommitted))
       .recover {
         case error =>
           val mappedError = combinedErrorMapper.lift(error).getOrElse(error)

--- a/server/servers/api/src/test/scala/com/prisma/api/mutations/DeadlockSpec.scala
+++ b/server/servers/api/src/test/scala/com/prisma/api/mutations/DeadlockSpec.scala
@@ -1,0 +1,176 @@
+package com.prisma.api.mutations
+
+import java.util.concurrent.Executors
+
+import com.prisma.api.ApiBaseSpec
+import com.prisma.shared.schema_dsl.SchemaDsl
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+class DeadlockSpec extends FlatSpec with Matchers with ApiBaseSpec {
+
+  implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(100))
+
+  "creating many items" should "not cause deadlocks" in {
+    val project = SchemaDsl() { schema =>
+      val comment = schema.model("Comment").field("text", _.String)
+      schema.model("Todo").oneToManyRelation("comments", "todo", comment).field("a", _.String)
+    }
+    database.setup(project)
+
+    implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(100))
+
+    def exec(i: Int) =
+      Future(
+        server.query(
+          s"""mutation {
+             |  createTodo(
+             |    data:{
+             |      a: "a"
+             |    }
+             |  ){
+             |    a
+             |  }
+             |}
+      """.stripMargin,
+          project
+        )
+      )
+
+    Await.result(Future.traverse(0 to 50)((i) => exec(i)), Duration.Inf)
+  }
+
+  "updating single item many times" should "not cause deadlocks" in {
+    val project = SchemaDsl() { schema =>
+      val comment = schema.model("Comment").field("text", _.String)
+      schema.model("Todo").oneToManyRelation("comments", "todo", comment).field("a", _.String)
+    }
+    database.setup(project)
+
+    val createResult = server.query(
+      """mutation {
+        |  createTodo(
+        |    data: {
+        |      comments: {
+        |        create: [{text: "comment1"}, {text: "comment2"}]
+        |      }
+        |    }
+        |  ){
+        |    id
+        |    comments { id }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    val todoId     = createResult.pathAsString("data.createTodo.id")
+    val comment1Id = createResult.pathAsString("data.createTodo.comments.[0].id")
+    val comment2Id = createResult.pathAsString("data.createTodo.comments.[1].id")
+
+    def exec(i: Int) =
+      Future(
+        server.query(
+          s"""mutation {
+             |  updateTodo(
+             |    where: { id: "${todoId}" }
+             |    data:{
+             |      a: "${i}"
+             |    }
+             |  ){
+             |    a
+             |  }
+             |}
+      """.stripMargin,
+          project
+        )
+      )
+
+    Await.result(Future.traverse(0 to 50)((i) => exec(i)), Duration.Inf)
+  }
+
+  "updating single item and relations many times" should "not cause deadlocks" in {
+    val project = SchemaDsl() { schema =>
+      val comment = schema.model("Comment").field("text", _.String)
+      schema.model("Todo").oneToManyRelation("comments", "todo", comment).field("a", _.String)
+    }
+    database.setup(project)
+
+    val createResult = server.query(
+      """mutation {
+        |  createTodo(
+        |    data: {
+        |      comments: {
+        |        create: [{text: "comment1"}, {text: "comment2"}]
+        |      }
+        |    }
+        |  ){
+        |    id
+        |    comments { id }
+        |  }
+        |}""".stripMargin,
+      project
+    )
+
+    val todoId     = createResult.pathAsString("data.createTodo.id")
+    val comment1Id = createResult.pathAsString("data.createTodo.comments.[0].id")
+    val comment2Id = createResult.pathAsString("data.createTodo.comments.[1].id")
+
+    def exec(i: Int) =
+      Future(
+        server.query(
+          s"""mutation {
+             |  updateTodo(
+             |    where: { id: "${todoId}" }
+             |    data:{
+             |      a: "${i}"
+             |      comments: {
+             |        update: [{where: {id: "${comment1Id}"}, data: {text: "update ${i}"}}]
+             |      }
+             |    }
+             |  ){
+             |    a
+             |  }
+             |}
+      """.stripMargin,
+          project
+        )
+      )
+
+    Await.result(Future.traverse(0 to 50)((i) => exec(i)), Duration.Inf)
+  }
+
+  "creating many items with relations" should "not cause deadlocks" in {
+    val project = SchemaDsl() { schema =>
+      val comment = schema.model("Comment").field("text", _.String)
+      schema.model("Todo").oneToManyRelation("comments", "todo", comment).field("a", _.String)
+    }
+    database.setup(project)
+
+    def exec(i: Int) =
+      Future(
+        server.query(
+          s"""mutation {
+               |  createTodo(
+               |    data:{
+               |      a: "a",
+               |      comments: {
+               |        create: [
+               |           {text: "first comment: ${i}"}
+               |        ]
+               |      }
+               |    }
+               |  ){
+               |    a
+               |  }
+               |}
+      """.stripMargin,
+          project
+        )
+      )
+
+    Await.result(Future.traverse(0 to 50)((i) => exec(i)), Duration.Inf)
+  }
+
+}


### PR DESCRIPTION
Prisma has tight control over data access patterns and can use this to provide sufficient guarantees without the prohibitively expensive Repeatable Reads isolation level that is the default in MySQL. Most other SQL databases (Oracle, SQL Server, PostgreSQL) default to Read Committed.

fixes #2060