### PR TITLE
Support for default service name and stage

### DIFF
--- a/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
@@ -41,6 +41,7 @@ case class ApiServer(
   val log: String => Unit = (msg: String) => logger.info(msg)
   val requestPrefix       = sys.env.getOrElse("ENV", "local")
   val projectFetcher      = apiDependencies.projectFetcher
+  val reservedSegments    = Set("private", "import", "export")
 
   import scala.concurrent.duration._
 
@@ -130,49 +131,36 @@ case class ApiServer(
     }
 
     logger.info(Json.toJson(LogData(LogKey.RequestNew, requestId)).toString())
-    pathPrefix(Segments(min = 2, max = 4)) { segments =>
+    pathPrefix(Segments(min = 0, max = 4)) { segments =>
       post {
-        def removeLastElementIfInSet(elements: List[String], set: Set[String]) = {
-          if (set.contains(elements.last)) {
-            elements.dropRight(1)
-          } else {
-            elements
-          }
-        }
-        val actualSegments    = removeLastElementIfInSet(segments, Set("private", "import", "export"))
-        val projectId         = ProjectId.fromSegments(actualSegments)
-        val projectIdAsString = projectId.asString
-
-        val apiSegment = if (segments.size == 3 || segments.size == 4) {
-          segments.last
-        } else {
-          ""
-        }
+        val (projectSegments, reservedSegment) = splitReservedSegment(segments)
+        val projectId                          = ProjectId.fromSegments(projectSegments)
+        val projectIdAsString                  = projectId.asString
 
         handleExceptions(toplevelExceptionHandler(requestId)) {
           extractRawRequest(requestId) { rawRequest =>
-            apiSegment match {
-              case "private" =>
+            reservedSegment match {
+              case None =>
+                throttleApiCallIfNeeded(projectId, rawRequest)
+
+              case Some("private") =>
                 val result = apiDependencies.requestHandler.handleRawRequestForPrivateApi(projectId = projectIdAsString, rawRequest = rawRequest)
                 result.onComplete(_ => logRequestEnd(projectIdAsString))
                 complete(result)
 
-              case "import" =>
+              case Some("import") =>
                 withRequestTimeout(5.minutes) {
                   val result = apiDependencies.requestHandler.handleRawRequestForImport(projectId = projectIdAsString, rawRequest = rawRequest)
                   result.onComplete(_ => logRequestEnd(projectIdAsString))
                   complete(result)
                 }
 
-              case "export" =>
+              case Some("export") =>
                 withRequestTimeout(5.minutes) {
                   val result = apiDependencies.requestHandler.handleRawRequestForExport(projectId = projectIdAsString, rawRequest = rawRequest)
                   result.onComplete(_ => logRequestEnd(projectIdAsString))
                   complete(result)
                 }
-
-              case _ =>
-                throttleApiCallIfNeeded(projectId, rawRequest)
             }
           }
         }
@@ -203,6 +191,14 @@ case class ApiServer(
           }
         }
       }
+    }
+  }
+
+  def splitReservedSegment(elements: List[String]): (List[String], Option[String]) = {
+    if (reservedSegments.contains(elements.last)) {
+      (elements.dropRight(1), elements.lastOption)
+    } else {
+      (elements, None)
     }
   }
 

--- a/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
@@ -199,7 +199,7 @@ case class ApiServer(
   }
 
   def splitReservedSegment(elements: List[String]): (List[String], Option[String]) = {
-    if (reservedSegments.contains(elements.last)) {
+    if (elements.nonEmpty && reservedSegments.contains(elements.last)) {
       (elements.dropRight(1), elements.lastOption)
     } else {
       (elements, None)

--- a/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
+++ b/server/servers/api/src/main/scala/com/prisma/api/server/ApiServer.scala
@@ -1,6 +1,7 @@
 package com.prisma.api.server
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Directives._
@@ -161,6 +162,9 @@ case class ApiServer(
                   result.onComplete(_ => logRequestEnd(projectIdAsString))
                   complete(result)
                 }
+
+              case Some(x) =>
+                complete(StatusCodes.BadRequest, s"Invalid path segment $x")
             }
           }
         }

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/Errors.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/Errors.scala
@@ -42,11 +42,12 @@ case class ProjectAlreadyExists(name: String, stage: String)
     extends AbstractDeployApiError(s"Service with name '$name' and stage '$stage' already exists", 4005)
 
 case class ReservedServiceName(name: String) extends AbstractDeployApiError(s"Service name $name is reserved. Please choose a different name.", 4006)
+case class ReservedStageName(stage: String)  extends AbstractDeployApiError(s"Stage name $stage is reserved. Please choose a different stage name.", 4007)
 
 object DeploymentInProgress
     extends AbstractDeployApiError(
       "You can not deploy to a service stage while there is a deployment in progress or a pending deployment scheduled already. Please try again after the deployment finished.",
-      4007
+      4008
     )
 
 object InvalidNames {

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/Errors.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/Errors.scala
@@ -11,8 +11,19 @@ trait DeployApiError extends Exception {
 
 abstract class AbstractDeployApiError(val message: String, val code: Int) extends DeployApiError
 
+// 20xx
 //case class InvalidName(name: String, entityType: String) extends AbstractDeployApiError(InvalidNames.default(name, entityType), 2008)
 
+// 30xx
+case class InvalidToken(reason: String) extends AbstractDeployApiError(s"Authentication token is invalid: $reason", 3015)
+
+object TokenExpired extends AbstractDeployApiError(s"Authentication token is expired", 3016)
+
+case class InvalidQuery(reason: String) extends AbstractDeployApiError(reason, 3017)
+
+case class UpdatedRelationAmbigous(reason: String) extends AbstractDeployApiError(reason, 3018)
+
+// 40xx
 case class InvalidProjectId(projectId: String)
     extends AbstractDeployApiError({
       val nameAndStage = ProjectId.fromEncodedString(projectId)
@@ -27,22 +38,16 @@ case class InvalidServiceStage(stage: String) extends AbstractDeployApiError(Inv
 
 case class InvalidRelationName(relationName: String) extends AbstractDeployApiError(InvalidNames.forRelation(relationName, "relation"), 4004)
 
-case class InvalidToken(reason: String) extends AbstractDeployApiError(s"Authentication token is invalid: $reason", 3015)
+case class ProjectAlreadyExists(name: String, stage: String)
+    extends AbstractDeployApiError(s"Service with name '$name' and stage '$stage' already exists", 4005)
 
-object TokenExpired extends AbstractDeployApiError(s"Authentication token is expired", 3016)
-
-case class InvalidQuery(reason: String) extends AbstractDeployApiError(reason, 3017)
-
-case class UpdatedRelationAmbigous(reason: String) extends AbstractDeployApiError(reason, 3018)
+case class ReservedServiceName(name: String) extends AbstractDeployApiError(s"Service name $name is reserved. Please choose a different name.", 4006)
 
 object DeploymentInProgress
     extends AbstractDeployApiError(
       "You can not deploy to a service stage while there is a deployment in progress or a pending deployment scheduled already. Please try again after the deployment finished.",
-      4004
+      4007
     )
-
-case class ProjectAlreadyExists(name: String, stage: String)
-    extends AbstractDeployApiError(s"Service with name '$name' and stage '$stage' already exists", 4005)
 
 object InvalidNames {
   def mustStartUppercase(name: String, entityType: String): String =

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/mutations/AddProjectMutation.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/mutations/AddProjectMutation.scala
@@ -1,7 +1,7 @@
 package com.prisma.deploy.schema.mutations
 
 import com.prisma.deploy.connector.{DeployConnector, MigrationPersistence, ProjectPersistence}
-import com.prisma.deploy.schema.{InvalidServiceName, InvalidServiceStage, ProjectAlreadyExists, ReservedServiceName}
+import com.prisma.deploy.schema._
 import com.prisma.deploy.validation.NameConstraints
 import com.prisma.shared.models._
 import com.prisma.utils.await.AwaitUtils
@@ -51,7 +51,8 @@ case class AddProjectMutation(
   }
 
   private def validate(): Unit = {
-    if (ProjectId.reservedServiceNames.contains(args.name)) throw ReservedServiceName(args.name)
+    if (ProjectId.reservedServiceAndStageNames.contains(args.name)) throw ReservedServiceName(args.name)
+    if (ProjectId.reservedServiceAndStageNames.contains(args.stage)) throw ReservedStageName(args.stage)
     if (!NameConstraints.isValidServiceName(args.name)) throw InvalidServiceName(args.name)
     if (!NameConstraints.isValidServiceStage(args.stage)) throw InvalidServiceStage(args.stage)
 

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/database/schema/mutations/AddProjectMutationSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/database/schema/mutations/AddProjectMutationSpec.scala
@@ -55,7 +55,7 @@ class AddProjectMutationSpec extends FlatSpec with Matchers with DeploySpecBase 
   }
 
   "AddProjectMutation" should "fail if a service name is reserved" in {
-    ProjectId.reservedServiceNames.foreach { reserved =>
+    ProjectId.reservedServiceAndStageNames.foreach { reserved =>
       server.queryThatMustFail(
         s"""
            |mutation {
@@ -71,6 +71,27 @@ class AddProjectMutationSpec extends FlatSpec with Matchers with DeploySpecBase 
            |}
       """.stripMargin,
         4006
+      )
+    }
+  }
+
+  "AddProjectMutation" should "fail if a stage name is reserved" in {
+    ProjectId.reservedServiceAndStageNames.foreach { reserved =>
+      server.queryThatMustFail(
+        s"""
+           |mutation {
+           |  addProject(input: {
+           |    name: "default",
+           |    stage: "$reserved"
+           |  }) {
+           |    project {
+           |      name
+           |      stage
+           |    }
+           |  }
+           |}
+      """.stripMargin,
+        4007
       )
     }
   }

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/database/schema/mutations/AddProjectMutationSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/database/schema/mutations/AddProjectMutationSpec.scala
@@ -53,4 +53,25 @@ class AddProjectMutationSpec extends FlatSpec with Matchers with DeploySpecBase 
       4005
     )
   }
+
+  "AddProjectMutation" should "fail if a service name is reserved" in {
+    ProjectId.reservedServiceNames.foreach { reserved =>
+      server.queryThatMustFail(
+        s"""
+           |mutation {
+           |  addProject(input: {
+           |    name: "$reserved",
+           |    stage: "default"
+           |  }) {
+           |    project {
+           |      name
+           |      stage
+           |    }
+           |  }
+           |}
+      """.stripMargin,
+        4006
+      )
+    }
+  }
 }

--- a/server/servers/subscriptions/src/main/scala/com/prisma/websocket/WebsocketServer.scala
+++ b/server/servers/subscriptions/src/main/scala/com/prisma/websocket/WebsocketServer.scala
@@ -39,7 +39,7 @@ case class WebsocketServer(dependencies: SubscriptionDependencies, prefix: Strin
   override def onStop: Future[_] = Future { responseSubscription.unsubscribe }
 
   val innerRoutes =
-    pathPrefix(Segments(min = 2, max = 3)) { segments =>
+    pathPrefix(Segments(min = 0, max = 3)) { segments =>
       get {
         val projectId = ProjectId.fromSegments(segments).asString
 

--- a/server/shared-models/src/main/scala/com/prisma/shared/models/Ids.scala
+++ b/server/shared-models/src/main/scala/com/prisma/shared/models/Ids.scala
@@ -10,7 +10,7 @@ object ProjectId {
   private val defaultService     = "default"
   private val defaultStage       = "default"
 
-  val reservedServiceNames = Seq("cluster", "export", "import")
+  val reservedServiceAndStageNames = Seq("cluster", "export", "import")
 
   def fromEncodedString(str: String): ProjectId = {
     val parts = str.split(stageSeparator)

--- a/server/shared-models/src/main/scala/com/prisma/shared/models/Ids.scala
+++ b/server/shared-models/src/main/scala/com/prisma/shared/models/Ids.scala
@@ -10,10 +10,13 @@ object ProjectId {
   private val defaultService     = "default"
   private val defaultStage       = "default"
 
+  val reservedServiceNames = Seq("cluster", "export", "import")
+
   def fromEncodedString(str: String): ProjectId = {
     val parts = str.split(stageSeparator)
     val name  = parts(0)
     val stage = parts(1)
+
     ProjectId(name, stage)
   }
 

--- a/server/shared-models/src/main/scala/com/prisma/shared/models/Ids.scala
+++ b/server/shared-models/src/main/scala/com/prisma/shared/models/Ids.scala
@@ -23,7 +23,7 @@ object ProjectId {
   def toEncodedString(name: String, stage: String): String = toEncodedString(List(name, stage))
 
   def toEncodedString(segments: List[String]): String = {
-    segments match {
+    segments.filter(_.nonEmpty) match {
       case Nil =>
         defaultService + stageSeparator + defaultStage
 

--- a/server/shared-models/src/main/scala/com/prisma/shared/models/Ids.scala
+++ b/server/shared-models/src/main/scala/com/prisma/shared/models/Ids.scala
@@ -7,6 +7,8 @@ case class ProjectId(name: String, stage: String) {
 object ProjectId {
   private val workspaceSeparator = '~'
   private val stageSeparator     = '@'
+  private val defaultService     = "default"
+  private val defaultStage       = "default"
 
   def fromEncodedString(str: String): ProjectId = {
     val parts = str.split(stageSeparator)
@@ -19,6 +21,12 @@ object ProjectId {
 
   def toEncodedString(segments: List[String]): String = {
     segments match {
+      case Nil =>
+        defaultService + stageSeparator + defaultStage
+
+      case name :: Nil =>
+        name + stageSeparator + defaultStage
+
       case name :: stage :: Nil =>
         name + stageSeparator + stage
 
@@ -26,7 +34,7 @@ object ProjectId {
         workspace + workspaceSeparator + name + stageSeparator + stage
 
       case _ =>
-        sys.error("provided segments must either have size 2 or 3")
+        sys.error("Unsupported project ID encoding. ")
     }
   }
 

--- a/server/shared-models/src/test/scala/com/prisma/shared/models/ProjectIdSpec.scala
+++ b/server/shared-models/src/test/scala/com/prisma/shared/models/ProjectIdSpec.scala
@@ -1,0 +1,25 @@
+package com.prisma.shared.models
+
+import org.scalatest.{WordSpec, Matchers}
+
+class ProjectIdSpec extends WordSpec with Matchers {
+  ".toEncodedString" when {
+    "given neither service nor stage" should {
+      "assume the default name and stage" in {
+        ProjectId.toEncodedString(List.empty) shouldEqual "default@default"
+      }
+    }
+
+    "given no stage" should {
+      "add the default state of the service" in {
+        ProjectId.toEncodedString("test", "") shouldEqual "test@default"
+      }
+    }
+
+    "Fail if given invalid input" in {
+      assertThrows[RuntimeException] {
+        ProjectId.toEncodedString(List("too", "many", "segments", "given"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds support for default service names and stages:
* Makes it possible to deploy and query a service without name and stage, which will then deploy to the default service and default stage of the Prisma instance, routed under root `<prisma_url>/` (or explicitly at `<prisma_url>/default/default`).
* Makes it possible to deploy and query a service without a stage, which defaults to the `default` stage internally. The service is routed as `<prisma_url>/<service_name>` (or explicitly at `<prisma_url>/<service_name>/default`)

Export and import endpoints are still available on the simplified routes, e.g. `/export` is the endpoints for the `default/default` service, `/testService/export` the endpoint for the `testService/default` service.

To avoid ambiguities, this PR also introduces reserved service and stage names: `cluster`, `export`, and `import` can not be chosen as service or stage names.

