### PR TITLE
Support HMAC JWT auth for cluster API

### DIFF
--- a/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalDependencies.scala
+++ b/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalDependencies.scala
@@ -12,7 +12,7 @@ import com.prisma.auth.AuthImpl
 import com.prisma.deploy.DeployDependencies
 import com.prisma.deploy.connector.mysql.MySqlDeployConnector
 import com.prisma.deploy.migration.migrator.{AsyncMigrator, Migrator}
-import com.prisma.deploy.server.{ClusterAuthImpl, DummyClusterAuth}
+import com.prisma.deploy.server.auth.{AsymmetricClusterAuth, DummyClusterAuth, SymmetricClusterAuth}
 import com.prisma.image.{Converters, FunctionValidatorImpl, SingleServerProjectFetcher}
 import com.prisma.messagebus.pubsub.inmemory.InMemoryAkkaPubSub
 import com.prisma.messagebus.queue.inmemory.InMemoryAkkaQueue
@@ -42,9 +42,10 @@ case class PrismaLocalDependencies()(implicit val system: ActorSystem, val mater
 
   override lazy val migrator: Migrator = AsyncMigrator(migrationPersistence, projectPersistence, deployPersistencePlugin)
   override lazy val clusterAuth = {
-    sys.env.get("CLUSTER_PUBLIC_KEY") match {
-      case Some(publicKey) if publicKey.nonEmpty => ClusterAuthImpl(publicKey)
-      case _                                     => DummyClusterAuth()
+    (sys.env.get("PRISMA_MANAGEMENT_API_JWT_SECRET"), sys.env.get("CLUSTER_PUBLIC_KEY")) match {
+      case (Some(jwtSecret), _) if jwtSecret.nonEmpty => SymmetricClusterAuth(jwtSecret)
+      case (_, Some(publicKey)) if publicKey.nonEmpty => AsymmetricClusterAuth(publicKey)
+      case _                                          => DummyClusterAuth()
     }
   }
 

--- a/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
+++ b/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
@@ -14,7 +14,6 @@ import com.prisma.deploy.connector.DeployConnector
 import com.prisma.deploy.connector.mysql.MySqlDeployConnector
 import com.prisma.deploy.migration.migrator.{AsyncMigrator, Migrator}
 import com.prisma.deploy.schema.mutations.FunctionValidator
-import com.prisma.deploy.server.AsymmetricClusterAuth
 import com.prisma.deploy.server.auth.{AsymmetricClusterAuth, DummyClusterAuth, SymmetricClusterAuth}
 import com.prisma.image.{Converters, FunctionValidatorImpl, SingleServerProjectFetcher}
 import com.prisma.messagebus._

--- a/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
+++ b/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
@@ -14,7 +14,8 @@ import com.prisma.deploy.connector.DeployConnector
 import com.prisma.deploy.connector.mysql.MySqlDeployConnector
 import com.prisma.deploy.migration.migrator.{AsyncMigrator, Migrator}
 import com.prisma.deploy.schema.mutations.FunctionValidator
-import com.prisma.deploy.server.{ClusterAuthImpl, DummyClusterAuth}
+import com.prisma.deploy.server.AsymmetricClusterAuth
+import com.prisma.deploy.server.auth.{AsymmetricClusterAuth, DummyClusterAuth, SymmetricClusterAuth}
 import com.prisma.image.{Converters, FunctionValidatorImpl, SingleServerProjectFetcher}
 import com.prisma.messagebus._
 import com.prisma.messagebus.pubsub.inmemory.InMemoryAkkaPubSub
@@ -49,9 +50,10 @@ case class PrismaProdDependencies()(implicit val system: ActorSystem, val materi
 
   override lazy val migrator: Migrator = AsyncMigrator(migrationPersistence, projectPersistence, deployPersistencePlugin)
   override lazy val clusterAuth = {
-    sys.env.get("CLUSTER_PUBLIC_KEY") match {
-      case Some(publicKey) if publicKey.nonEmpty => ClusterAuthImpl(publicKey)
-      case _                                     => DummyClusterAuth()
+    (sys.env.get("PRISMA_MANAGEMENT_API_JWT_SECRET"), sys.env.get("CLUSTER_PUBLIC_KEY")) match {
+      case (Some(jwtSecret), _) if jwtSecret.nonEmpty => SymmetricClusterAuth(jwtSecret)
+      case (_, Some(publicKey)) if publicKey.nonEmpty => AsymmetricClusterAuth(publicKey)
+      case _                                          => DummyClusterAuth()
     }
   }
 

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/DeployDependencies.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/DeployDependencies.scala
@@ -7,7 +7,7 @@ import com.prisma.deploy.connector.DeployConnector
 import com.prisma.deploy.migration.migrator.Migrator
 import com.prisma.deploy.schema.SchemaBuilder
 import com.prisma.deploy.schema.mutations.FunctionValidator
-import com.prisma.deploy.server.ClusterAuth
+import com.prisma.deploy.server.auth.ClusterAuth
 import com.prisma.errors.ErrorReporter
 import com.prisma.messagebus.PubSubPublisher
 import com.prisma.utils.await.AwaitUtils

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/AsymmetricClusterAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/AsymmetricClusterAuth.scala
@@ -1,4 +1,4 @@
-package com.prisma.deploy.server
+package com.prisma.deploy.server.auth
 
 import java.time.Instant
 
@@ -7,22 +7,9 @@ import play.api.libs.json._
 
 import scala.util.{Failure, Success, Try}
 
-trait ClusterAuth {
-  def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit]
-}
-
-case class DummyClusterAuth() extends ClusterAuth {
-  override def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit] = {
-    println("Warning: Cluster authentication is disabled. To protect your cluster you should provide the environment variable 'CLUSTER_PUBLIC_KEY'.")
-    Success(())
-  }
-}
-
-case class ClusterAuthImpl(publicKey: String) extends ClusterAuth {
+case class AsymmetricClusterAuth(publicKey: String) extends ClusterAuth {
   import pdi.jwt.{Jwt, JwtAlgorithm, JwtOptions}
-
-  implicit val tokenGrantReads = Json.reads[TokenGrant]
-  implicit val tokenDataReads  = Json.reads[TokenData]
+  import ClusterAuth._
 
   override def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit] = Try {
     authHeaderOpt match {
@@ -81,6 +68,3 @@ case class ClusterAuthImpl(publicKey: String) extends ClusterAuth {
     }
   }
 }
-
-case class TokenData(grants: Vector[TokenGrant], exp: Long)
-case class TokenGrant(target: String, action: String)

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/ClusterAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/ClusterAuth.scala
@@ -1,0 +1,17 @@
+package com.prisma.deploy.server.auth
+
+import play.api.libs.json.Json
+
+import scala.util.Try
+
+object ClusterAuth {
+  implicit val tokenGrantReads = Json.reads[TokenGrant]
+  implicit val tokenDataReads  = Json.reads[TokenData]
+}
+
+trait ClusterAuth {
+  def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit]
+}
+
+case class TokenData(grants: Vector[TokenGrant], exp: Long)
+case class TokenGrant(target: String, action: String)

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/DummyClusterAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/DummyClusterAuth.scala
@@ -1,0 +1,15 @@
+package com.prisma.deploy.server.auth
+
+import scala.util.{Success, Try}
+
+case class DummyClusterAuth() extends ClusterAuth {
+  override def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit] = {
+    println(
+      "Warning: Cluster authentication is disabled. " +
+        "To protect your cluster you should provide one (not both) of the environment variables " +
+        "'CLUSTER_PUBLIC_KEY' (asymmetric, deprecated soon) or 'PRISMA_MANAGEMENT_API_JWT_SECRET' (symmetric)."
+    )
+
+    Success(())
+  }
+}

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/SymmetricClusterAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/SymmetricClusterAuth.scala
@@ -1,0 +1,70 @@
+package com.prisma.deploy.server.auth
+
+import java.time.Instant
+
+import com.prisma.deploy.schema.{InvalidToken, TokenExpired}
+import play.api.libs.json._
+
+import scala.util.{Failure, Success, Try}
+
+case class SymmetricClusterAuth(jwtSecret: String) extends ClusterAuth {
+  import pdi.jwt.{Jwt, JwtAlgorithm, JwtOptions}
+  import ClusterAuth._
+
+  override def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit] = Try {
+    authHeaderOpt match {
+      case None =>
+        throw InvalidToken("'Authorization' header not provided")
+
+      case Some(authHeader) =>
+        val jwtOptions = JwtOptions(signature = true, expiration = true)
+        val algorithms = Seq(JwtAlgorithm.HS256)
+        val decodedToken = Jwt.decodeRaw(
+          token = authHeader.stripPrefix("Bearer "),
+          key = jwtSecret,
+          algorithms = algorithms,
+          options = jwtOptions
+        )
+
+        decodedToken match {
+          case Failure(exception) =>
+            throw InvalidToken(s"Token can't be decoded: ${exception.getMessage}")
+
+          case Success(rawToken) =>
+            val token = parseToken(rawToken)
+            if ((token.exp * 1000) < Instant.now().toEpochMilli) {
+              throw TokenExpired
+            }
+
+            token.grants
+              .find(verifyGrant(name, stage, _))
+              .getOrElse(throw InvalidToken(s"Token contained ${token.grants.length} grants but none satisfied the request."))
+        }
+    }
+  }
+
+  private def verifyGrant(nameToCheck: String, stageToCheck: String, grant: TokenGrant): Boolean = {
+    val (grantedName: String, grantedStage: String) = grant.target.split("/").toVector match {
+      case Vector(service, stage) => (service, stage)
+      case invalid                => throw InvalidToken(s"Contained invalid grant '$invalid'")
+    }
+
+    if (grantedName == "" || grantedStage == "") {
+      throw InvalidToken(s"Both service and stage must be defined in grant '$grant'")
+    }
+
+    validate(nameToCheck, grantedName) && validate(stageToCheck, grantedStage)
+  }
+
+  private def validate(toValidate: String, granted: String): Boolean = granted match {
+    case "*" => true
+    case str => toValidate == str
+  }
+
+  private def parseToken(token: String): TokenData = {
+    Json.parse(token).asOpt[TokenData] match {
+      case None              => throw InvalidToken(s"Failed to parse token data")
+      case Some(parsedToken) => parsedToken
+    }
+  }
+}

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/server/auth/AsymmetricClusterAuthSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/server/auth/AsymmetricClusterAuthSpec.scala
@@ -1,21 +1,20 @@
-package com.prisma.deploy
+package com.prisma.deploy.server.auth
 
 import java.time.Instant
 
-import com.prisma.deploy.server.ClusterAuthImpl
 import org.scalatest.{FlatSpec, Matchers}
 
-class ClusterAuthSpec extends FlatSpec with Matchers {
+class AsymmetricClusterAuthSpec extends FlatSpec with Matchers {
 
   "Grant with wildcard for service and stage" should "give access to any service and stage" in {
-    val auth = ClusterAuthImpl(publicKey)
+    val auth = AsymmetricClusterAuth(publicKey)
     val jwt  = createJwt("""[{"target": "*/*", "action": "*"}]""")
 
     auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe true
   }
 
   "Grant with invalid target" should "not give access" in {
-    val auth  = ClusterAuthImpl(publicKey)
+    val auth  = AsymmetricClusterAuth(publicKey)
     val name  = "service"
     val stage = "stage"
 
@@ -30,7 +29,7 @@ class ClusterAuthSpec extends FlatSpec with Matchers {
   }
 
   "Grant with wildcard for stage" should "give access to defined service only" in {
-    val auth = ClusterAuthImpl(publicKey)
+    val auth = AsymmetricClusterAuth(publicKey)
     val jwt  = createJwt("""[{"target": "service/*", "action": "*"}]""")
 
     auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe true
@@ -38,7 +37,7 @@ class ClusterAuthSpec extends FlatSpec with Matchers {
   }
 
   "An expired token" should "not give access" in {
-    val auth = ClusterAuthImpl(publicKey)
+    val auth = AsymmetricClusterAuth(publicKey)
     val jwt  = createJwt("""[{"target": "service/*", "action": "*"}]""", expiration = (Instant.now().toEpochMilli / 1000) - 5)
 
     auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe false

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/server/auth/SymmetricClusterAuthSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/server/auth/SymmetricClusterAuthSpec.scala
@@ -1,0 +1,55 @@
+package com.prisma.deploy.server.auth
+
+import java.time.Instant
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class SymmetricClusterAuthSpec extends FlatSpec with Matchers {
+
+  val testSecret = "test"
+
+  "Grant with wildcard for service and stage" should "give access to any service and stage" in {
+    val auth = SymmetricClusterAuth(testSecret)
+    val jwt  = createJwt("""[{"target": "*/*", "action": "*"}]""")
+
+    auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe true
+  }
+
+  "Grant with invalid target" should "not give access" in {
+    val auth  = SymmetricClusterAuth(testSecret)
+    val name  = "service"
+    val stage = "stage"
+
+    auth.verify(name, stage, Some(createJwt("""[{"target": "/*", "action": "*"}]"""))).isSuccess shouldBe false
+    auth.verify(name, stage, Some(createJwt("""[{"target": "*", "action": "*"}]"""))).isSuccess shouldBe false
+    auth.verify(name, stage, Some(createJwt("""[{"target": "abba", "action": "*"}]"""))).isSuccess shouldBe false
+    auth.verify(name, stage, Some(createJwt("""[{"target": "/*/*", "action": "*"}]"""))).isSuccess shouldBe false
+    auth.verify(name, stage, Some(createJwt("""[{"target": "*/*/*", "action": "*"}]"""))).isSuccess shouldBe false
+    auth.verify(name, stage, Some(createJwt("""[{"target": "", "action": "*"}]"""))).isSuccess shouldBe false
+    auth.verify(name, stage, Some(createJwt("""[{"target": "/", "action": "*"}]"""))).isSuccess shouldBe false
+    auth.verify(name, stage, Some(createJwt("""[{"target": "//", "action": "*"}]"""))).isSuccess shouldBe false
+  }
+
+  "Grant with wildcard for stage" should "give access to defined service only" in {
+    val auth = SymmetricClusterAuth(testSecret)
+    val jwt  = createJwt("""[{"target": "service/*", "action": "*"}]""")
+
+    auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe true
+    auth.verify("otherService", "stage", Some(jwt)).isSuccess shouldBe false
+  }
+
+  "An expired token" should "not give access" in {
+    val auth = SymmetricClusterAuth(testSecret)
+    val jwt  = createJwt("""[{"target": "service/*", "action": "*"}]""", expiration = (Instant.now().toEpochMilli / 1000) - 5)
+
+    auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe false
+    auth.verify("otherService", "stage", Some(jwt)).isSuccess shouldBe false
+  }
+
+  def createJwt(grants: String, expiration: Long = (Instant.now().toEpochMilli / 1000) + 5) = {
+    import pdi.jwt.{Jwt, JwtAlgorithm}
+
+    val claim = s"""{"grants": $grants, "exp": $expiration}"""
+    Jwt.encode(claim = claim, algorithm = JwtAlgorithm.HS256, key = testSecret)
+  }
+}

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/specutils/DeployTestDependencies.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/specutils/DeployTestDependencies.scala
@@ -8,7 +8,7 @@ import com.prisma.deploy.connector.DeployConnector
 import com.prisma.deploy.connector.mysql.MySqlDeployConnector
 import com.prisma.deploy.migration.validation.SchemaError
 import com.prisma.deploy.schema.mutations.{FunctionInput, FunctionValidator}
-import com.prisma.deploy.server.DummyClusterAuth
+import com.prisma.deploy.server.auth.DummyClusterAuth
 import com.prisma.errors.{BugsnagErrorReporter, ErrorReporter}
 import com.prisma.messagebus.pubsub.inmemory.InMemoryAkkaPubSub
 import com.prisma.shared.models.Project


### PR DESCRIPTION
Adds support for HS256 JWT authentication to the cluster API.
The decision which auth module is loaded is made during server bootup: 
* If the env var `PRISMA_MANAGEMENT_API_JWT_SECRET` is present and non-empty, it will load the HS256 JWT auth module.
* If the above env var is not present or empty, and the env var `CLUSTER_PUBLIC_KEY` (the "old" env var for cluster API auth) is present, it will load the RS256 JWT auth module.
* If both env vars are present and non-empty, the HS256 module is loaded.
* If both env vars are not present or empty, no auth module will be loaded and the cluster API is unsecured.