### PR TITLE
Rename cluster to management

### DIFF
--- a/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalDependencies.scala
+++ b/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalDependencies.scala
@@ -12,7 +12,7 @@ import com.prisma.config.{ConfigLoader, PrismaConfig}
 import com.prisma.connectors.utils.ConnectorUtils
 import com.prisma.deploy.DeployDependencies
 import com.prisma.deploy.migration.migrator.{AsyncMigrator, Migrator}
-import com.prisma.deploy.server.auth.{AsymmetricClusterAuth, DummyClusterAuth, SymmetricClusterAuth}
+import com.prisma.deploy.server.auth.{AsymmetricManagementAuth, DummyManagementAuth, SymmetricManagementAuth}
 import com.prisma.image.{Converters, FunctionValidatorImpl, SingleServerProjectFetcher}
 import com.prisma.messagebus.pubsub.inmemory.InMemoryAkkaPubSub
 import com.prisma.messagebus.queue.inmemory.InMemoryAkkaQueue
@@ -44,11 +44,11 @@ case class PrismaLocalDependencies()(implicit val system: ActorSystem, val mater
   }
 
   override lazy val migrator: Migrator = AsyncMigrator(migrationPersistence, projectPersistence, deployConnector)
-  override lazy val clusterAuth = {
+  override lazy val managementAuth = {
     (config.managementApiSecret, config.legacySecret) match {
-      case (Some(jwtSecret), _) if jwtSecret.nonEmpty => SymmetricClusterAuth(jwtSecret)
-      case (_, Some(publicKey)) if publicKey.nonEmpty => AsymmetricClusterAuth(publicKey)
-      case _                                          => DummyClusterAuth()
+      case (Some(jwtSecret), _) if jwtSecret.nonEmpty => SymmetricManagementAuth(jwtSecret)
+      case (_, Some(publicKey)) if publicKey.nonEmpty => AsymmetricManagementAuth(publicKey)
+      case _                                          => DummyManagementAuth()
     }
   }
 

--- a/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalMain.scala
+++ b/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalMain.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.prisma.akkautil.http.ServerExecutor
 import com.prisma.api.server.ApiServer
-import com.prisma.deploy.server.ClusterServer
+import com.prisma.deploy.server.ManagementServer
 import com.prisma.subscriptions.SimpleSubscriptionsServer
 import com.prisma.websocket.WebsocketServer
 import com.prisma.workers.WorkerServer
@@ -19,7 +19,7 @@ object PrismaLocalMain extends App {
 
   ServerExecutor(
     port = dependencies.config.port.getOrElse(4466),
-    ClusterServer("cluster", dependencies.config.server2serverSecret),
+    ManagementServer("management", dependencies.config.server2serverSecret),
     WebsocketServer(dependencies),
     ApiServer(dependencies.apiSchemaBuilder),
     SimpleSubscriptionsServer(),

--- a/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
+++ b/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
@@ -14,7 +14,7 @@ import com.prisma.deploy.DeployDependencies
 import com.prisma.deploy.connector.DeployConnector
 import com.prisma.deploy.migration.migrator.{AsyncMigrator, Migrator}
 import com.prisma.deploy.schema.mutations.FunctionValidator
-import com.prisma.deploy.server.auth.{AsymmetricClusterAuth, DummyClusterAuth, SymmetricClusterAuth}
+import com.prisma.deploy.server.auth.{AsymmetricManagementAuth, DummyManagementAuth, SymmetricManagementAuth}
 import com.prisma.image.{Converters, FunctionValidatorImpl, SingleServerProjectFetcher}
 import com.prisma.messagebus._
 import com.prisma.messagebus.pubsub.inmemory.InMemoryAkkaPubSub
@@ -51,11 +51,11 @@ case class PrismaProdDependencies()(implicit val system: ActorSystem, val materi
   }
 
   override lazy val migrator: Migrator = AsyncMigrator(migrationPersistence, projectPersistence, deployConnector)
-  override lazy val clusterAuth = {
+  override lazy val managementAuth = {
     (config.managementApiSecret, config.legacySecret) match {
-      case (Some(jwtSecret), _) if jwtSecret.nonEmpty => SymmetricClusterAuth(jwtSecret)
-      case (_, Some(publicKey)) if publicKey.nonEmpty => AsymmetricClusterAuth(publicKey)
-      case _                                          => DummyClusterAuth()
+      case (Some(jwtSecret), _) if jwtSecret.nonEmpty => SymmetricManagementAuth(jwtSecret)
+      case (_, Some(publicKey)) if publicKey.nonEmpty => AsymmetricManagementAuth(publicKey)
+      case _                                          => DummyManagementAuth()
     }
   }
 

--- a/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdMain.scala
+++ b/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdMain.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.prisma.akkautil.http.ServerExecutor
 import com.prisma.api.server.ApiServer
-import com.prisma.deploy.server.ClusterServer
+import com.prisma.deploy.server.ManagementServer
 import com.prisma.subscriptions.SimpleSubscriptionsServer
 import com.prisma.utils.boolean.BooleanUtils._
 import com.prisma.websocket.WebsocketServer
@@ -14,11 +14,12 @@ object PrismaProdMain extends App {
   implicit val system       = ActorSystem("single-server")
   implicit val materializer = ActorMaterializer()
   implicit val dependencies = PrismaProdDependencies()
+
   dependencies.initialize()(system.dispatcher)
 
-  val port                 = dependencies.config.port.getOrElse(4466)
-  val includeClusterServer = dependencies.config.managmentApiEnabled
-  val servers = includeClusterServer.flatMap(_.toOption(ClusterServer("cluster", dependencies.config.server2serverSecret))) ++ List(
+  val port                    = dependencies.config.port.getOrElse(4466)
+  val includeManagementServer = dependencies.config.managmentApiEnabled
+  val servers = includeManagementServer.flatMap(_.toOption(ManagementServer("management", dependencies.config.server2serverSecret))) ++ List(
     WebsocketServer(dependencies),
     ApiServer(dependencies.apiSchemaBuilder),
     SimpleSubscriptionsServer(),

--- a/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdMain.scala
+++ b/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdMain.scala
@@ -17,9 +17,9 @@ object PrismaProdMain extends App {
 
   dependencies.initialize()(system.dispatcher)
 
-  val port                    = dependencies.config.port.getOrElse(4466)
-  val includeManagementServer = dependencies.config.managmentApiEnabled
-  val servers = includeManagementServer.flatMap(_.toOption(ManagementServer("management", dependencies.config.server2serverSecret))) ++ List(
+  val port              = dependencies.config.port.getOrElse(4466)
+  val includeMgmtServer = dependencies.config.managmentApiEnabled
+  val servers = includeMgmtServer.flatMap(_.toOption(ManagementServer("management", dependencies.config.server2serverSecret))) ++ List(
     WebsocketServer(dependencies),
     ApiServer(dependencies.apiSchemaBuilder),
     SimpleSubscriptionsServer(),

--- a/server/libs/sangria-utils/src/main/scala/com/prisma/sangria/utils/ErrorHandler.scala
+++ b/server/libs/sangria-utils/src/main/scala/com/prisma/sangria/utils/ErrorHandler.scala
@@ -16,7 +16,7 @@ case class ErrorHandler(
     projectId: Option[String] = None,
     errorCodeExtractor: Throwable => Option[Int]
 ) {
-  private val internalErrorMessage = s"Whoops. Looks like an internal server error. Search your cluster logs for request ID: $requestId"
+  private val internalErrorMessage = s"Whoops. Looks like an internal server error. Search your server logs for request ID: $requestId"
 
   lazy val handler: PartialFunction[(ResultMarshaller, Throwable), HandledException] = {
     case (marshaller: ResultMarshaller, error: Throwable) if errorCodeExtractor(error).isDefined =>

--- a/server/prisma.yml
+++ b/server/prisma.yml
@@ -1,0 +1,9 @@
+port: 4466
+databases:
+  default:
+    connector: postgres
+    active: true
+    host: 127.0.0.1
+    port: 5432
+    user: postgres
+    password: prisma

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/DeployDependencies.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/DeployDependencies.scala
@@ -7,7 +7,7 @@ import com.prisma.deploy.connector.DeployConnector
 import com.prisma.deploy.migration.migrator.Migrator
 import com.prisma.deploy.schema.SchemaBuilder
 import com.prisma.deploy.schema.mutations.FunctionValidator
-import com.prisma.deploy.server.auth.ClusterAuth
+import com.prisma.deploy.server.auth.ManagementAuth
 import com.prisma.errors.ErrorReporter
 import com.prisma.messagebus.PubSubPublisher
 import com.prisma.shared.models.ProjectIdEncoder
@@ -23,16 +23,16 @@ trait DeployDependencies extends AwaitUtils {
   implicit def self: DeployDependencies
 
   def migrator: Migrator
-  def clusterAuth: ClusterAuth
+  def managementAuth: ManagementAuth
   def invalidationPublisher: PubSubPublisher[String]
   def apiAuth: Auth
   def deployConnector: DeployConnector
   def functionValidator: FunctionValidator
   def projectIdEncoder: ProjectIdEncoder
 
-  lazy val projectPersistence   = deployConnector.projectPersistence
-  lazy val migrationPersistence = deployConnector.migrationPersistence
-  lazy val clusterSchemaBuilder = SchemaBuilder()
+  lazy val projectPersistence      = deployConnector.projectPersistence
+  lazy val migrationPersistence    = deployConnector.migrationPersistence
+  lazy val managementSchemaBuilder = SchemaBuilder()
 
   def initialize()(implicit ec: ExecutionContext): Unit = {
     await(deployConnector.initialize(), seconds = 30)

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/SchemaBuilder.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/SchemaBuilder.scala
@@ -263,6 +263,6 @@ case class SchemaBuilderImpl(
   }
 
   private def verifyAuthOrThrow(name: String, stage: String, authHeader: Option[String]) = {
-    dependencies.clusterAuth.verify(name, stage, authHeader).get
+    dependencies.managementAuth.verify(name, stage, authHeader).get
   }
 }

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/SchemaBuilder.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/SchemaBuilder.scala
@@ -61,7 +61,7 @@ case class SchemaBuilderImpl(
     listProjectsField,
     listMigrationsField,
     projectField,
-    clusterInfoField,
+    serverInfoField,
     generateProjectTokenField
   )
 
@@ -140,10 +140,10 @@ case class SchemaBuilderImpl(
     }
   )
 
-  val clusterInfoField: Field[SystemUserContext, Unit] = Field(
-    "clusterInfo",
-    ClusterInfoType.Type,
-    description = Some("Information about the cluster"),
+  val serverInfoField: Field[SystemUserContext, Unit] = Field(
+    "serverInfo",
+    ServerInfoType.Type,
+    description = Some("Information about the server"),
     resolve = (ctx) => ()
   )
 

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/types/ServerInfoType.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/types/ServerInfoType.scala
@@ -3,13 +3,13 @@ package com.prisma.deploy.schema.types
 import com.prisma.deploy.schema.SystemUserContext
 import sangria.schema._
 
-object ClusterInfoType {
+object ServerInfoType {
   val version = sys.env.getOrElse("CLUSTER_VERSION", sys.error("Env var CLUSTER_VERSION required but not found."))
   val commit  = sys.env.getOrElse("COMMIT_SHA", sys.error("Env var COMMIT_SHA required but not found."))
 
   lazy val Type: ObjectType[SystemUserContext, Unit] = ObjectType(
-    "ClusterInfo",
-    "Information about the deployed cluster",
+    "ServerInfo",
+    "Information about the deployed server",
     fields[SystemUserContext, Unit](
       Field("version", StringType, resolve = _ => version),
       Field("commit", StringType, resolve = _ => commit)

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/ManagementServer.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/ManagementServer.scala
@@ -52,7 +52,7 @@ case class ManagementServer(prefix: String = "", server2serverSecret: Option[Str
   }
 
   val innerRoutes = extractRequest { req =>
-    val requestId            = requestPrefix + ":cluster:" + createCuid()
+    val requestId            = requestPrefix + ":management:" + createCuid()
     val requestBeginningTime = System.currentTimeMillis()
 
     def logRequestEnd(projectId: Option[String] = None, clientId: Option[String] = None) = {

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/ManagementServer.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/ManagementServer.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
-case class ClusterServer(prefix: String = "", server2serverSecret: Option[String])(
+case class ManagementServer(prefix: String = "", server2serverSecret: Option[String])(
     implicit system: ActorSystem,
     materializer: ActorMaterializer,
     dependencies: DeployDependencies
@@ -38,7 +38,7 @@ case class ClusterServer(prefix: String = "", server2serverSecret: Option[String
   import com.prisma.deploy.server.JsonMarshalling._
   import system.dispatcher
 
-  val schemaBuilder: SchemaBuilder           = dependencies.clusterSchemaBuilder
+  val schemaBuilder: SchemaBuilder           = dependencies.managementSchemaBuilder
   val projectPersistence: ProjectPersistence = dependencies.projectPersistence
   val log: String => Unit                    = (msg: String) => logger.info(msg)
   val requestPrefix                          = sys.env.getOrElse("ENV", "local")

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/AsymmetricManagementAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/AsymmetricManagementAuth.scala
@@ -7,9 +7,9 @@ import play.api.libs.json._
 
 import scala.util.{Failure, Success, Try}
 
-case class AsymmetricClusterAuth(publicKey: String) extends ClusterAuth {
-  import ClusterAuth._
+case class AsymmetricManagementAuth(publicKey: String) extends ManagementAuth {
   import pdi.jwt.{Jwt, JwtAlgorithm, JwtOptions}
+  import ManagementAuth._
 
   override def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit] = Try {
     authHeaderOpt match {

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/DummyManagementAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/DummyManagementAuth.scala
@@ -2,7 +2,7 @@ package com.prisma.deploy.server.auth
 
 import scala.util.{Success, Try}
 
-case class DummyClusterAuth() extends ClusterAuth {
+case class DummyManagementAuth() extends ManagementAuth {
   override def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit] = {
     println(
       "Warning: Cluster authentication is disabled. " +

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/DummyManagementAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/DummyManagementAuth.scala
@@ -5,9 +5,9 @@ import scala.util.{Success, Try}
 case class DummyManagementAuth() extends ManagementAuth {
   override def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit] = {
     println(
-      "Warning: Cluster authentication is disabled. " +
-        "To protect your cluster you should provide one (not both) of the environment variables " +
-        "'CLUSTER_PUBLIC_KEY' (asymmetric, deprecated soon) or 'PRISMA_MANAGEMENT_API_JWT_SECRET' (symmetric)."
+      "Warning: Management API authentication is disabled. " +
+        "To protect your management server you should provide one (not both) of the environment variables " +
+        "'CLUSTER_PUBLIC_KEY' (asymmetric, deprecated soon) or 'PRISMA_MANAGEMENT_API_JWT_SECRET' (symmetric JWT)."
     )
 
     Success(())

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/ManagementAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/ManagementAuth.scala
@@ -4,12 +4,12 @@ import play.api.libs.json.Json
 
 import scala.util.Try
 
-object ClusterAuth {
+object ManagementAuth {
   implicit val tokenGrantReads = Json.reads[TokenGrant]
   implicit val tokenDataReads  = Json.reads[TokenData]
 }
 
-trait ClusterAuth {
+trait ManagementAuth {
   def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit]
 }
 

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/SymmetricManagementAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/SymmetricManagementAuth.scala
@@ -7,9 +7,9 @@ import play.api.libs.json._
 
 import scala.util.{Failure, Success, Try}
 
-case class SymmetricClusterAuth(jwtSecret: String) extends ClusterAuth {
-  import ClusterAuth._
+case class SymmetricManagementAuth(jwtSecret: String) extends ManagementAuth {
   import pdi.jwt.{Jwt, JwtAlgorithm, JwtOptions}
+  import ManagementAuth._
 
   override def verify(name: String, stage: String, authHeaderOpt: Option[String]): Try[Unit] = Try {
     authHeaderOpt match {

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/database/schema/queries/ServerInfoSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/database/schema/queries/ServerInfoSpec.scala
@@ -4,19 +4,19 @@ import com.prisma.deploy.specutils.DeploySpecBase
 import com.prisma.shared.models.ProjectId
 import org.scalatest.{FlatSpec, Matchers}
 
-class ClusterInfoSpec extends FlatSpec with Matchers with DeploySpecBase {
+class ServerInfoSpec extends FlatSpec with Matchers with DeploySpecBase {
 
-  "ClusterInfo query" should "return cluster version" in {
+  "ServerInfo query" should "return server version" in {
     val (project, _) = setupProject(basicTypesGql)
     val nameAndStage = testDependencies.projectIdEncoder.fromEncodedString(project.id)
     val result       = server.query(s"""
                                        |query {
-                                       |  clusterInfo {
+                                       |  serverInfo {
                                        |    version
                                        |  }
                                        |}
       """.stripMargin)
 
-    result.pathAsString("data.clusterInfo.version") shouldEqual sys.env("CLUSTER_VERSION")
+    result.pathAsString("data.serverInfo.version") shouldEqual sys.env("CLUSTER_VERSION")
   }
 }

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/server/auth/AsymmetricManagementAuthSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/server/auth/AsymmetricManagementAuthSpec.scala
@@ -4,17 +4,17 @@ import java.time.Instant
 
 import org.scalatest.{FlatSpec, Matchers}
 
-class AsymmetricClusterAuthSpec extends FlatSpec with Matchers {
+class AsymmetricManagementAuthSpec extends FlatSpec with Matchers {
 
   "Grant with wildcard for service and stage" should "give access to any service and stage" in {
-    val auth = AsymmetricClusterAuth(publicKey)
+    val auth = AsymmetricManagementAuth(publicKey)
     val jwt  = createJwt("""[{"target": "*/*", "action": "*"}]""")
 
     auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe true
   }
 
   "Grant with invalid target" should "not give access" in {
-    val auth  = AsymmetricClusterAuth(publicKey)
+    val auth  = AsymmetricManagementAuth(publicKey)
     val name  = "service"
     val stage = "stage"
 
@@ -29,7 +29,7 @@ class AsymmetricClusterAuthSpec extends FlatSpec with Matchers {
   }
 
   "Grant with wildcard for stage" should "give access to defined service only" in {
-    val auth = AsymmetricClusterAuth(publicKey)
+    val auth = AsymmetricManagementAuth(publicKey)
     val jwt  = createJwt("""[{"target": "service/*", "action": "*"}]""")
 
     auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe true
@@ -37,7 +37,7 @@ class AsymmetricClusterAuthSpec extends FlatSpec with Matchers {
   }
 
   "An expired token" should "not give access" in {
-    val auth = AsymmetricClusterAuth(publicKey)
+    val auth = AsymmetricManagementAuth(publicKey)
     val jwt  = createJwt("""[{"target": "service/*", "action": "*"}]""", expiration = (Instant.now().toEpochMilli / 1000) - 5)
 
     auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe false

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/server/auth/SymmetricManagementAuthSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/server/auth/SymmetricManagementAuthSpec.scala
@@ -4,19 +4,19 @@ import java.time.Instant
 
 import org.scalatest.{FlatSpec, Matchers}
 
-class SymmetricClusterAuthSpec extends FlatSpec with Matchers {
+class SymmetricManagementAuthSpec extends FlatSpec with Matchers {
 
   val testSecret = "test"
 
   "Grant with wildcard for service and stage" should "give access to any service and stage" in {
-    val auth = SymmetricClusterAuth(testSecret)
+    val auth = SymmetricManagementAuth(testSecret)
     val jwt  = createJwt("""[{"target": "*/*", "action": "*"}]""")
 
     auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe true
   }
 
   "Grant with invalid target" should "not give access" in {
-    val auth  = SymmetricClusterAuth(testSecret)
+    val auth  = SymmetricManagementAuth(testSecret)
     val name  = "service"
     val stage = "stage"
 
@@ -31,7 +31,7 @@ class SymmetricClusterAuthSpec extends FlatSpec with Matchers {
   }
 
   "Grant with wildcard for stage" should "give access to defined service only" in {
-    val auth = SymmetricClusterAuth(testSecret)
+    val auth = SymmetricManagementAuth(testSecret)
     val jwt  = createJwt("""[{"target": "service/*", "action": "*"}]""")
 
     auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe true
@@ -39,7 +39,7 @@ class SymmetricClusterAuthSpec extends FlatSpec with Matchers {
   }
 
   "An expired token" should "not give access" in {
-    val auth = SymmetricClusterAuth(testSecret)
+    val auth = SymmetricManagementAuth(testSecret)
     val jwt  = createJwt("""[{"target": "service/*", "action": "*"}]""", expiration = (Instant.now().toEpochMilli / 1000) - 5)
 
     auth.verify("service", "stage", Some(jwt)).isSuccess shouldBe false

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/specutils/TestDeployDependencies.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/specutils/TestDeployDependencies.scala
@@ -8,7 +8,7 @@ import com.prisma.connectors.utils.ConnectorUtils
 import com.prisma.deploy.DeployDependencies
 import com.prisma.deploy.migration.validation.SchemaError
 import com.prisma.deploy.schema.mutations.{FunctionInput, FunctionValidator}
-import com.prisma.deploy.server.auth.DummyClusterAuth
+import com.prisma.deploy.server.auth.DummyManagementAuth
 import com.prisma.errors.{BugsnagErrorReporter, ErrorReporter}
 import com.prisma.messagebus.pubsub.inmemory.InMemoryAkkaPubSub
 import com.prisma.shared.models.{Project, ProjectIdEncoder}
@@ -22,7 +22,7 @@ case class TestDeployDependencies()(implicit val system: ActorSystem, val materi
 
   implicit val reporter: ErrorReporter    = BugsnagErrorReporter(sys.env.getOrElse("BUGSNAG_API_KEY", ""))
   override lazy val migrator              = TestMigrator(migrationPersistence, deployConnector.deployMutactionExecutor)
-  override lazy val clusterAuth           = DummyClusterAuth()
+  override lazy val managementAuth        = DummyManagementAuth()
   override lazy val invalidationPublisher = InMemoryAkkaPubSub[String]()
 
   override def apiAuth = AuthImpl

--- a/server/shared-models/src/main/scala/com/prisma/shared/models/ProjectId.scala
+++ b/server/shared-models/src/main/scala/com/prisma/shared/models/ProjectId.scala
@@ -6,7 +6,7 @@ case class ProjectIdEncoder(stageSeparator: Char) {
   val workspaceSeparator: Char     = '~'
   private val defaultService       = "default"
   private val defaultStage         = "default"
-  val reservedServiceAndStageNames = Seq("cluster", "export", "import")
+  val reservedServiceAndStageNames = Seq("cluster", "management", "export", "import")
 
   def fromEncodedString(str: String): ProjectId = {
     val parts = str.split(stageSeparator)


### PR DESCRIPTION
The `cluster` endpoint was never really descriptive of what it does - managing deployments and the deployed services themselves, basically providing an overarching management API for your Prisma instance or cluster. This PR renames the `cluster` endpoint and related code to `management`.