### PR TITLE
Update Upsert Docs re Nested Mutation Functionality

### DIFF
--- a/docs/1.2/04-Reference/03-Prisma-API/04-Mutations.md
+++ b/docs/1.2/04-Reference/03-Prisma-API/04-Mutations.md
@@ -108,6 +108,8 @@ mutation {
 
 > **Note**: `create` and `update` are of the same type as the `data` object in the `createUser` and `updateUser` mutations.
 
+> **Note**: At this time, it is not possible to include nested mutations within upsert; nested mutations included within upsert will be ignored. For more information, see [#1579](https://github.com/graphcool/prisma/issues/1579) & [#2194](https://github.com/graphcool/prisma/issues/2194).
+
 ### Deleting nodes
 
 To delete nodes, all we have to do is to use the [select the node(s)](!alias-utee3eiquo#node-selection) to be deleted in a `delete` mutation.


### PR DESCRIPTION
Because including nested mutations within an upsert mutation is an expected, core functionality, it should be documented that this is not currently possible.