### PR TITLE
Add validations and extra warnings to deploy when updating relations

### DIFF
--- a/server/.buildkite/pipeline.sh
+++ b/server/.buildkite/pipeline.sh
@@ -21,6 +21,9 @@ static=$(printf "    - label: \":mysql: MySql API connector\"
 
     - label: \":scala: subscriptions\"
       command: cd server && ./.buildkite/scripts/test.sh subscriptions mysql
+
+    - label: \":scala: integration-tests-mysql\"
+      command: cd server && ./.buildkite/scripts/test.sh integration-tests-mysql mysql
 ")
 
 optional=""
@@ -66,9 +69,6 @@ do
 
     - label: \":scala: workers [$connector]\"
       command: cd server && ./.buildkite/scripts/test.sh workers $connector
-
-    - label: \":scala: integration-tests [$connector]\"
-      command: cd server && ./.buildkite/scripts/test.sh integrationTests $connector
 
 ")
 

--- a/server/.buildkite/pipeline.sh
+++ b/server/.buildkite/pipeline.sh
@@ -18,8 +18,8 @@ static=$(printf "    - label: \":mysql: MySql API connector\"
     - label: \":postgres: Postgres deploy connector\"
       command: cd server && ./.buildkite/scripts/test.sh deploy-connector-postgresql postgres
 
-    - label: \":scala: integration-tests-postgres\"
-      command: cd server && ./.buildkite/scripts/test.sh integration-tests-mysql postgres
+    #- label: \":scala: integration-tests-postgres\"
+    #  command: cd server && ./.buildkite/scripts/test.sh integration-tests-mysql postgres
 
     # Libs are not specific to a connector, simply run with mysql
     - label: \":scala: libs\"

--- a/server/.buildkite/pipeline.sh
+++ b/server/.buildkite/pipeline.sh
@@ -9,11 +9,17 @@ static=$(printf "    - label: \":mysql: MySql API connector\"
     - label: \":mysql: MySql deploy connector\"
       command: cd server && ./.buildkite/scripts/test.sh deploy-connector-mysql mysql
 
+    - label: \":scala: integration-tests-mysql\"
+      command: cd server && ./.buildkite/scripts/test.sh integration-tests mysql
+
     - label: \":postgres: Postgres API connector\"
       command: cd server && ./.buildkite/scripts/test.sh api-connector-postgresql postgres
 
     - label: \":postgres: Postgres deploy connector\"
       command: cd server && ./.buildkite/scripts/test.sh deploy-connector-postgresql postgres
+
+    - label: \":scala: integration-tests-postgres\"
+      command: cd server && ./.buildkite/scripts/test.sh integration-tests postgres
 
     # Libs are not specific to a connector, simply run with mysql
     - label: \":scala: libs\"
@@ -21,9 +27,7 @@ static=$(printf "    - label: \":mysql: MySql API connector\"
 
     - label: \":scala: subscriptions\"
       command: cd server && ./.buildkite/scripts/test.sh subscriptions mysql
-
-    - label: \":scala: integration-tests-mysql\"
-      command: cd server && ./.buildkite/scripts/test.sh integration-tests-mysql mysql
+      
 ")
 
 optional=""

--- a/server/.buildkite/pipeline.sh
+++ b/server/.buildkite/pipeline.sh
@@ -10,7 +10,7 @@ static=$(printf "    - label: \":mysql: MySql API connector\"
       command: cd server && ./.buildkite/scripts/test.sh deploy-connector-mysql mysql
 
     - label: \":scala: integration-tests-mysql\"
-      command: cd server && ./.buildkite/scripts/test.sh integration-tests mysql
+      command: cd server && ./.buildkite/scripts/test.sh integration-tests-mysql mysql
 
     - label: \":postgres: Postgres API connector\"
       command: cd server && ./.buildkite/scripts/test.sh api-connector-postgresql postgres
@@ -19,7 +19,7 @@ static=$(printf "    - label: \":mysql: MySql API connector\"
       command: cd server && ./.buildkite/scripts/test.sh deploy-connector-postgresql postgres
 
     - label: \":scala: integration-tests-postgres\"
-      command: cd server && ./.buildkite/scripts/test.sh integration-tests postgres
+      command: cd server && ./.buildkite/scripts/test.sh integration-tests-mysql postgres
 
     # Libs are not specific to a connector, simply run with mysql
     - label: \":scala: libs\"

--- a/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/database/MysqlDeployDatabaseQueryBuilder.scala
+++ b/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/database/MysqlDeployDatabaseQueryBuilder.scala
@@ -1,5 +1,6 @@
 package com.prisma.deploy.connector.mysql.database
 
+import com.prisma.shared.models.RelationSide.RelationSide
 import com.prisma.shared.models.{Field, Model}
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc.{PositionedParameters, SQLActionBuilder}
@@ -12,6 +13,10 @@ object MysqlDeployDatabaseQueryBuilder {
 
   def existsByRelation(projectId: String, relationTableName: String): SQLActionBuilder = {
     sql"select exists (select `id` from `#$projectId`.`#$relationTableName`)"
+  }
+
+  def existsDuplicateByRelationAndSide(projectId: String, relationTableName: String, relationSide: RelationSide): SQLActionBuilder = {
+    sql"select exists (select Count(*)from `#$projectId`.`#$relationTableName` Group by `#${relationSide.toString}` having Count(*) > 1)"
   }
 
   def existsNullByModelAndScalarField(projectId: String, modelName: String, fieldName: String) = {

--- a/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/impls/MysqlClientDbQueries.scala
+++ b/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/impls/MysqlClientDbQueries.scala
@@ -2,6 +2,7 @@ package com.prisma.deploy.connector.mysql.impls
 
 import com.prisma.deploy.connector.ClientDbQueries
 import com.prisma.deploy.connector.mysql.database.MysqlDeployDatabaseQueryBuilder
+import com.prisma.shared.models.RelationSide.RelationSide
 import com.prisma.shared.models.{Field, Model, Project}
 import slick.dbio.Effect.Read
 import slick.jdbc.MySQLProfile.api._
@@ -19,6 +20,11 @@ case class MysqlClientDbQueries(project: Project, clientDatabase: Database)(impl
 
   def existsByRelation(relationId: String): Future[Boolean] = {
     val query = MysqlDeployDatabaseQueryBuilder.existsByRelation(project.id, relationId)
+    clientDatabase.run(readOnlyBoolean(query)).map(_.head).recover { case _: java.sql.SQLSyntaxErrorException => false }
+  }
+
+  def existsDuplicateByRelationAndSide(relationId: String, relationSide: RelationSide): Future[Boolean] = {
+    val query = MysqlDeployDatabaseQueryBuilder.existsDuplicateByRelationAndSide(project.id, relationId, relationSide)
     clientDatabase.run(readOnlyBoolean(query)).map(_.head).recover { case _: java.sql.SQLSyntaxErrorException => false }
   }
 

--- a/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/PostgresDeployConnector.scala
+++ b/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/PostgresDeployConnector.scala
@@ -3,7 +3,7 @@ package com.prisma.deploy.connector.postgresql
 import com.prisma.config.DatabaseConfig
 import com.prisma.deploy.connector._
 import com.prisma.deploy.connector.postgresql.database.{InternalDatabaseSchema, PostgresDeployDatabaseMutationBuilder, TelemetryTable}
-import com.prisma.deploy.connector.postgresql.impls.{PostgresClientDbQueries, DeployMutactionExecutorImpl, MigrationPersistenceImpl, ProjectPersistenceImpl}
+import com.prisma.deploy.connector.postgresql.impls.{PostgresClientDbQueries, PostgresDeployMutactionExecutor, MigrationPersistenceImpl, ProjectPersistenceImpl}
 import com.prisma.shared.models.{Project, ProjectIdEncoder}
 import org.joda.time.DateTime
 import slick.dbio.Effect.Read
@@ -19,7 +19,7 @@ case class PostgresDeployConnector(dbConfig: DatabaseConfig)(implicit ec: Execut
 
   override lazy val projectPersistence: ProjectPersistence           = ProjectPersistenceImpl(internalDatabase)
   override lazy val migrationPersistence: MigrationPersistence       = MigrationPersistenceImpl(internalDatabase)
-  override lazy val deployMutactionExecutor: DeployMutactionExecutor = DeployMutactionExecutorImpl(internalDatabaseRoot)
+  override lazy val deployMutactionExecutor: DeployMutactionExecutor = PostgresDeployMutactionExecutor(internalDatabaseRoot)
 
   override def createProjectDatabase(id: String): Future[Unit] = {
     val action = PostgresDeployDatabaseMutationBuilder.createClientDatabaseForProject(projectId = id)

--- a/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/PostgresDeployConnector.scala
+++ b/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/PostgresDeployConnector.scala
@@ -3,7 +3,7 @@ package com.prisma.deploy.connector.postgresql
 import com.prisma.config.DatabaseConfig
 import com.prisma.deploy.connector._
 import com.prisma.deploy.connector.postgresql.database.{InternalDatabaseSchema, PostgresDeployDatabaseMutationBuilder, TelemetryTable}
-import com.prisma.deploy.connector.postgresql.impls.{ClientDbQueriesImpl, DeployMutactionExecutorImpl, MigrationPersistenceImpl, ProjectPersistenceImpl}
+import com.prisma.deploy.connector.postgresql.impls.{PostgresClientDbQueries, DeployMutactionExecutorImpl, MigrationPersistenceImpl, ProjectPersistenceImpl}
 import com.prisma.shared.models.{Project, ProjectIdEncoder}
 import org.joda.time.DateTime
 import slick.dbio.Effect.Read
@@ -46,7 +46,7 @@ case class PostgresDeployConnector(dbConfig: DatabaseConfig)(implicit ec: Execut
     internalDatabaseRoot.run(action)
   }
 
-  override def clientDBQueries(project: Project): ClientDbQueries      = ClientDbQueriesImpl(project, internalDatabaseRoot)
+  override def clientDBQueries(project: Project): ClientDbQueries      = PostgresClientDbQueries(project, internalDatabaseRoot)
   override def getOrCreateTelemetryInfo(): Future[TelemetryInfo]       = internalDatabase.run(TelemetryTable.getOrCreateInfo())
   override def updateTelemetryInfo(lastPinged: DateTime): Future[Unit] = internalDatabase.run(TelemetryTable.updateInfo(lastPinged)).map(_ => ())
   override def projectIdEncoder: ProjectIdEncoder                      = ProjectIdEncoder('$')

--- a/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/database/PostgresDeployDatabaseQueryBuilder.scala
+++ b/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/database/PostgresDeployDatabaseQueryBuilder.scala
@@ -1,5 +1,6 @@
 package com.prisma.deploy.connector.postgresql.database
 
+import com.prisma.shared.models.RelationSide.RelationSide
 import com.prisma.shared.models.{Field, Model}
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.{PositionedParameters, SQLActionBuilder}
@@ -12,6 +13,10 @@ object PostgresDeployDatabaseQueryBuilder {
 
   def existsByRelation(projectId: String, relationId: String): SQLActionBuilder = {
     sql"""select exists (select "id" from "#$projectId"."#$relationId")"""
+  }
+
+  def existsDuplicateByRelationAndSide(projectId: String, relationTableName: String, relationSide: RelationSide): SQLActionBuilder = {
+    sql"""select exists (select Count(*)from "#$projectId"."#$relationTableName" Group by "${relationSide.toString}" having Count(*) > 1)"""
   }
 
   def existsNullByModelAndScalarField(projectId: String, modelName: String, fieldName: String) = {

--- a/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/impls/PostgresDeployMutactionExecutor.scala
+++ b/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/impls/PostgresDeployMutactionExecutor.scala
@@ -6,7 +6,7 @@ import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class DeployMutactionExecutorImpl(
+case class PostgresDeployMutactionExecutor(
     database: Database
 )(implicit ec: ExecutionContext)
     extends DeployMutactionExecutor {

--- a/server/connectors/deploy-connector/src/main/scala/com/prisma/deploy/connector/DeployConnector.scala
+++ b/server/connectors/deploy-connector/src/main/scala/com/prisma/deploy/connector/DeployConnector.scala
@@ -1,5 +1,6 @@
 package com.prisma.deploy.connector
 
+import com.prisma.shared.models.RelationSide.RelationSide
 import org.joda.time.DateTime
 import com.prisma.shared.models.{Field, Model, Project, ProjectIdEncoder}
 
@@ -31,6 +32,7 @@ case class TelemetryInfo(id: String, lastPing: Option[DateTime])
 trait ClientDbQueries {
   def existsByModel(modelName: String): Future[Boolean]
   def existsByRelation(relationId: String): Future[Boolean]
+  def existsDuplicateByRelationAndSide(relationId: String, side: RelationSide): Future[Boolean]
   def existsNullByModelAndField(model: Model, field: Field): Future[Boolean]
   def enumValueIsInUse(models: Vector[Model], enumName: String, value: String): Future[Boolean]
 }

--- a/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/AddingOptionalBackRelationDuringMigrationSpec.scala
+++ b/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/AddingOptionalBackRelationDuringMigrationSpec.scala
@@ -1,0 +1,238 @@
+package com.prisma.integration
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class AddingOptionalBackRelationDuringMigrationSpec extends FlatSpec with Matchers with IntegrationBaseSpec {
+
+  "Adding a missing back-relation of non-list type" should "work when there are no violating occurences of Team" in {
+
+    val schema =
+      """type Team {
+        |  name: String! @unique
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: Team @relation(name: "TeamMatchLeft")
+        |  teamRight: Team @relation(name: "TeamMatchRight")
+        |  winner: Team @relation(name: "TeamMatchWinner")
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query(
+      """mutation{createMatch(data:{
+        |                           number:1
+        |                           teamLeft:{create:{name: "Bayern"}},
+        |                           teamRight:{create:{name: "Real"}},
+        |                           winner:{connect:{name: "Real"}}
+        |                           }
+        |){number}}""",
+      project
+    )
+
+    val matches = apiServer.query("""{matches{number, teamLeft{name},teamRight{name},winner{name}}}""", project)
+    matches.toString should be("""{"data":{"matches":[{"number":1,"teamLeft":{"name":"Bayern"},"teamRight":{"name":"Real"},"winner":{"name":"Real"}}]}}""")
+
+    val teams = apiServer.query("""{teams{name}}""", project)
+    teams.toString should be("""{"data":{"teams":[{"name":"Bayern"},{"name":"Real"}]}}""")
+
+    val schema1 =
+      """type Team {
+        |  name: String! @unique
+        |  win: Match @relation(name: "TeamMatchWinner")
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: Team @relation(name: "TeamMatchLeft")
+        |  teamRight: Team @relation(name: "TeamMatchRight")
+        |  winner: Team @relation(name: "TeamMatchWinner")
+        |}"""
+
+    val updatedProject = deployServer.deploySchema(project, schema1)
+
+    val updatedTeams = apiServer.query("""{teams{name, win{number}}}""", updatedProject)
+    updatedTeams.toString should be("""{"data":{"teams":[{"name":"Bayern","win":null},{"name":"Real","win":{"number":1}}]}}""")
+  }
+
+  "Adding a missing back-relation of list type" should "work when there is only one pair yet" in {
+
+    val schema =
+      """type Team {
+        |  name: String! @unique
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: Team @relation(name: "TeamMatchLeft")
+        |  teamRight: Team @relation(name: "TeamMatchRight")
+        |  winner: Team @relation(name: "TeamMatchWinner")
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query(
+      """mutation{createMatch(data:{
+        |                           number:1
+        |                           teamLeft:{create:{name: "Bayern"}},
+        |                           teamRight:{create:{name: "Real"}},
+        |                           winner:{connect:{name: "Real"}}
+        |                           }
+        |){number}}""",
+      project
+    )
+
+    val matches = apiServer.query("""{matches{number, teamLeft{name},teamRight{name},winner{name}}}""", project)
+    matches.toString should be("""{"data":{"matches":[{"number":1,"teamLeft":{"name":"Bayern"},"teamRight":{"name":"Real"},"winner":{"name":"Real"}}]}}""")
+
+    val teams = apiServer.query("""{teams{name}}""", project)
+    teams.toString should be("""{"data":{"teams":[{"name":"Bayern"},{"name":"Real"}]}}""")
+
+    val schema1 =
+      """type Team {
+        |  name: String! @unique
+        |  wins: [Match!]! @relation(name: "TeamMatchWinner")
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: Team @relation(name: "TeamMatchLeft")
+        |  teamRight: Team @relation(name: "TeamMatchRight")
+        |  winner: Team @relation(name: "TeamMatchWinner")
+        |}"""
+
+    val updatedProject = deployServer.deploySchema(project, schema1)
+
+    val updatedTeams = apiServer.query("""{teams{name, wins{number}}}""", updatedProject)
+    updatedTeams.toString should be("""{"data":{"teams":[{"name":"Bayern","wins":[]},{"name":"Real","wins":[{"number":1}]}]}}""")
+  }
+
+  "Adding a missing back-relation of list type" should "work when there are already multiple relation pairs" in {
+
+    val schema =
+      """type Team {
+        |  name: String! @unique
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: Team @relation(name: "TeamMatchLeft")
+        |  teamRight: Team @relation(name: "TeamMatchRight")
+        |  winner: Team @relation(name: "TeamMatchWinner")
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query(
+      """mutation{createMatch(data:{
+        |                           number:1
+        |                           teamLeft:{create:{name: "Bayern"}},
+        |                           teamRight:{create:{name: "Real"}},
+        |                           winner:{connect:{name: "Real"}}
+        |                           }
+        |){number}}""",
+      project
+    )
+
+    apiServer.query(
+      """mutation{createMatch(data:{
+        |                           number:2
+        |                           teamLeft:{connect:{name: "Bayern"}},
+        |                           teamRight:{connect:{name: "Real"}},
+        |                           winner:{connect:{name: "Real"}}
+        |                           }
+        |){number}}""",
+      project
+    )
+
+    val matches = apiServer.query("""{matches{number, teamLeft{name},teamRight{name},winner{name}}}""", project)
+    matches.toString should be(
+      """{"data":{"matches":[{"number":1,"teamLeft":{"name":"Bayern"},"teamRight":{"name":"Real"},"winner":{"name":"Real"}},{"number":2,"teamLeft":{"name":"Bayern"},"teamRight":{"name":"Real"},"winner":{"name":"Real"}}]}}""")
+
+    val teams = apiServer.query("""{teams{name}}""", project)
+    teams.toString should be("""{"data":{"teams":[{"name":"Bayern"},{"name":"Real"}]}}""")
+
+    val schema1 =
+      """type Team {
+        |  name: String! @unique
+        |  wins: [Match!]! @relation(name: "TeamMatchWinner")
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: Team @relation(name: "TeamMatchLeft")
+        |  teamRight: Team @relation(name: "TeamMatchRight")
+        |  winner: Team @relation(name: "TeamMatchWinner")
+        |}"""
+
+    val updatedProject = deployServer.deploySchema(project, schema1)
+
+    val updatedTeams = apiServer.query("""{teams{name, wins{number}}}""", updatedProject)
+    updatedTeams.toString should be("""{"data":{"teams":[{"name":"Bayern","wins":[]},{"name":"Real","wins":[{"number":1},{"number":2}]}]}}""")
+  }
+
+  "Adding a missing back-relation of non-list type" should "not work when there are already multiple relation pairs" in {
+
+    val schema =
+      """type Team {
+        |  name: String! @unique
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: Team @relation(name: "TeamMatchLeft")
+        |  teamRight: Team @relation(name: "TeamMatchRight")
+        |  winner: Team @relation(name: "TeamMatchWinner")
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query(
+      """mutation{createMatch(data:{
+        |                           number:1
+        |                           teamLeft:{create:{name: "Bayern"}},
+        |                           teamRight:{create:{name: "Real"}},
+        |                           winner:{connect:{name: "Real"}}
+        |                           }
+        |){number}}""",
+      project
+    )
+
+    apiServer.query(
+      """mutation{createMatch(data:{
+        |                           number:2
+        |                           teamLeft:{connect:{name: "Bayern"}},
+        |                           teamRight:{connect:{name: "Real"}},
+        |                           winner:{connect:{name: "Real"}}
+        |                           }
+        |){number}}""",
+      project
+    )
+
+    val matches = apiServer.query("""{matches{number, teamLeft{name},teamRight{name},winner{name}}}""", project)
+    matches.toString should be(
+      """{"data":{"matches":[{"number":1,"teamLeft":{"name":"Bayern"},"teamRight":{"name":"Real"},"winner":{"name":"Real"}},{"number":2,"teamLeft":{"name":"Bayern"},"teamRight":{"name":"Real"},"winner":{"name":"Real"}}]}}""")
+
+    val teams = apiServer.query("""{teams{name}}""", project)
+    teams.toString should be("""{"data":{"teams":[{"name":"Bayern"},{"name":"Real"}]}}""")
+
+    val schema1 =
+      """type Team {
+        |  name: String! @unique
+        |  wins: Match @relation(name: "TeamMatchWinner")
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: Team @relation(name: "TeamMatchLeft")
+        |  teamRight: Team @relation(name: "TeamMatchRight")
+        |  winner: Team @relation(name: "TeamMatchWinner")
+        |}"""
+
+    val res = deployServer.deploySchemaThatMustError(project, schema1)
+
+    res.toString should be(
+      """{"data":{"deploy":{"migration":{"applied":0,"revision":0},"errors":[{"description":"You are adding a singular backrelation field to a type but there are already pairs in the relation that would violate that constraint."}],"warnings":[]}}}""")
+  }
+}

--- a/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/ChangingFromRelationToScalarOrBackSpec.scala
+++ b/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/ChangingFromRelationToScalarOrBackSpec.scala
@@ -1,0 +1,125 @@
+package com.prisma.integration
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class ChangingFromRelationToScalarOrBackSpec extends FlatSpec with Matchers with IntegrationBaseSpec {
+
+  "Changing a field from scalar to relation" should "work when there is no data yet" in {
+
+    val schema =
+      """type A {
+        |  a: String! @unique
+        |  b: String
+        |}
+        |
+        |type B {
+        |  b: String! @unique
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    val schema1 =
+      """type A {
+        |  a: String! @unique
+        |  b: B
+        |}
+        |
+        |type B {
+        |  b: String! @unique
+        |}"""
+
+    deployServer.deploySchema(project, schema1)
+  }
+
+  "Changing a field from scalar to relation" should "work when there is already data and should delete the old column" in {
+
+    val schema =
+      """type A {
+        |  a: String! @unique
+        |  b: String
+        |}
+        |
+        |type B {
+        |  b: String! @unique
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query("""mutation{createA(data:{a:"A", b: "B"}){a}}""", project)
+
+    val as = apiServer.query("""{as{a}}""", project)
+    as.toString should be("""{"data":{"as":[{"a":"A"}]}}""")
+
+    val schema1 =
+      """type A {
+        |  a: String! @unique
+        |  b: B
+        |}
+        |
+        |type B {
+        |  b: String! @unique
+        |}"""
+
+    deployServer.deploySchemaThatMustWarn(project, schema1, force = true)
+  }
+
+  "Changing a relation to scalar" should "work when there is no data yet" in {
+
+    val schema =
+      """type A {
+        |  a: String! @unique
+        |  b: B
+        |}
+        |
+        |type B {
+        |  b: String! @unique
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    val schema1 =
+      """type A {
+        |  a: String! @unique
+        |  b: String
+        |}
+        |
+        |type B {
+        |  b: String! @unique
+        |}"""
+
+    deployServer.deploySchema(project, schema1)
+  }
+
+  "Changing a relation to scalar" should "work when there is already data" in {
+
+    val schema =
+      """type A {
+        |  a: String! @unique
+        |  b: B
+        |}
+        |
+        |type B {
+        |  b: String! @unique
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query("""mutation{createA(data:{a:"A", b: {b: "B"}}){a}}""", project)
+
+    val as = apiServer.query("""{as{a, b{b}}}""", project)
+    as.toString should be("""{"data":{"as":[{"a":"A","b":{"b":"B"}}]}}""")
+
+    val schema1 =
+      """type A {
+        |  a: String! @unique
+        |  b: String
+        |}
+        |
+        |type B {
+        |  b: String! @unique
+        |}"""
+
+    deployServer.deploySchema(project, schema1)
+  }
+
+}

--- a/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/ChangingFromRelationToScalarOrBackSpec.scala
+++ b/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/ChangingFromRelationToScalarOrBackSpec.scala
@@ -104,7 +104,7 @@ class ChangingFromRelationToScalarOrBackSpec extends FlatSpec with Matchers with
 
     val (project, _) = setupProject(schema)
 
-    apiServer.query("""mutation{createA(data:{a:"A", b: {b: "B"}}){a}}""", project)
+    apiServer.query("""mutation{createA(data:{a:"A", b: {create:{b: "B"}}}){a}}""", project)
 
     val as = apiServer.query("""{as{a, b{b}}}""", project)
     as.toString should be("""{"data":{"as":[{"a":"A","b":{"b":"B"}}]}}""")
@@ -119,7 +119,7 @@ class ChangingFromRelationToScalarOrBackSpec extends FlatSpec with Matchers with
         |  b: String! @unique
         |}"""
 
-    deployServer.deploySchema(project, schema1)
+    deployServer.deploySchemaThatMustWarn(project, schema1, force = true)
   }
 
 }

--- a/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/SeveralRelationsBetweenSameModelsIntegrationSpec.scala
+++ b/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/SeveralRelationsBetweenSameModelsIntegrationSpec.scala
@@ -240,7 +240,7 @@ class SeveralRelationsBetweenSameModelsIntegrationSpec extends FlatSpec with Mat
         |  title: String
         |}"""
 
-    deployServer.deploySchemaThatMustError(project, schema1)
+    deployServer.deploySchemaThatMustErrorWithCode(project, schema1, errorCode = 3018)
   }
 
   "Going from two named relations between the same models to one named one without a backrelation" should "work" in {

--- a/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/SeveralRelationsBetweenSameModelsIntegrationSpec.scala
+++ b/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/SeveralRelationsBetweenSameModelsIntegrationSpec.scala
@@ -419,7 +419,36 @@ class SeveralRelationsBetweenSameModelsIntegrationSpec extends FlatSpec with Mat
 
   }
 
-  "Several missing backrelations on the same type and one unnamed relation on the other side" should "work when there are relation directives provided" in {
+  "One missing backrelation and one unnamed relation on the other side" should "error" in {
+
+    val schema =
+      """type TeamMatch {
+        |  key: String! @unique
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    val schema1 =
+      """type TeamMatch {
+        |  key: String! @unique
+        |  match: Match
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: TeamMatch @relation(name: "TeamMatchLeft")
+        |}"""
+
+    val res = deployServer.deploySchemaThatMustError(project, schema1)
+    res.toString should be(
+      """{"data":{"deploy":{"migration":null,"errors":[{"description":"You are trying to set the relation 'TeamMatchLeft' from `Match` to `TeamMatch` and are only providing a relation directive on `Match`. Since there is also a relation field without a relation directive on `TeamMatch` pointing towards `Match` that is ambiguous. Please provide the same relation directive on `TeamMatch` if this is supposed to be the same relation. If you meant to create two separate relations without backrelations please provide a relation directive with a different name on `nameB`."}],"warnings":[]}}}""")
+  }
+
+  "Several missing backrelations on the same type and one unnamed relation on the other side" should "error" in {
 
     val schema =
       """type TeamMatch {
@@ -448,7 +477,6 @@ class SeveralRelationsBetweenSameModelsIntegrationSpec extends FlatSpec with Mat
     val res = deployServer.deploySchemaThatMustError(project, schema1)
     res.toString should be(
       """{"data":{"deploy":{"migration":null,"errors":[{"description":"You are trying to set the relation 'TeamMatchLeft' from `Match` to `TeamMatch` and are only providing a relation directive on `Match`. Since there is also a relation field without a relation directive on `TeamMatch` pointing towards `Match` that is ambiguous. Please provide the same relation directive on `TeamMatch` if this is supposed to be the same relation. If you meant to create two separate relations without backrelations please provide a relation directive with a different name on `nameB`."},{"description":"You are trying to set the relation 'TeamMatchRight' from `Match` to `TeamMatch` and are only providing a relation directive on `Match`. Since there is also a relation field without a relation directive on `TeamMatch` pointing towards `Match` that is ambiguous. Please provide the same relation directive on `TeamMatch` if this is supposed to be the same relation. If you meant to create two separate relations without backrelations please provide a relation directive with a different name on `nameB`."},{"description":"You are trying to set the relation 'TeamMatchWinner' from `Match` to `TeamMatch` and are only providing a relation directive on `Match`. Since there is also a relation field without a relation directive on `TeamMatch` pointing towards `Match` that is ambiguous. Please provide the same relation directive on `TeamMatch` if this is supposed to be the same relation. If you meant to create two separate relations without backrelations please provide a relation directive with a different name on `nameB`."}],"warnings":[]}}}""")
-
   }
 
 }

--- a/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/SeveralRelationsBetweenSameModelsIntegrationSpec.scala
+++ b/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/SeveralRelationsBetweenSameModelsIntegrationSpec.scala
@@ -337,4 +337,33 @@ class SeveralRelationsBetweenSameModelsIntegrationSpec extends FlatSpec with Mat
     unchangedRelationContent.toString should be("""{"data":{"as":[{"title":"A1","b":{"title":"B1"}}]}}""")
   }
 
+  "Several missing backrelations on the same type" should "work when there are relation directives provided" in {
+
+    val schema =
+      """type TeamMatch {
+        |  key: String! @unique
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    val schema1 =
+      """type TeamMatch {
+        |  key: String! @unique
+        |}
+        |
+        |type Match {
+        |  number: Int @unique
+        |  teamLeft: TeamMatch @relation(name: "TeamMatchLeft")
+        |  teamRight: TeamMatch @relation(name: "TeamMatchRight")
+        |  winner: TeamMatch @relation(name: "TeamMatchWinner")
+        |}"""
+    val updatedProject = deployServer.deploySchema(project, schema1)
+
+    updatedProject.schema.relations.size should be(3)
+  }
+
 }

--- a/server/libs/json-utils/src/main/scala/com/prisma/utils/json/PlayJson.scala
+++ b/server/libs/json-utils/src/main/scala/com/prisma/utils/json/PlayJson.scala
@@ -133,7 +133,7 @@ trait PlayJsonExtensions extends JsonUtils {
 
       (shouldFail, shouldWarn) match {
         case (true, false) =>
-          require(requirement = errors.nonEmpty, message = s"The query had to result in a failure but it returned no errors.")
+          require(requirement = errors.nonEmpty || hasErrors, message = s"The query had to result in a failure but it returned no errors.")
           require(requirement = warnings.isEmpty, message = s"The query had to result in a success but it returned warnings.")
 
         case (false, false) =>
@@ -145,7 +145,7 @@ trait PlayJsonExtensions extends JsonUtils {
           require(requirement = warnings.nonEmpty, message = s"The query had to result in a warning but it returned no warnings.")
 
         case (true, true) =>
-          require(requirement = errors.nonEmpty, message = s"The query had to result in a failure but it returned no errors.")
+          require(requirement = errors.nonEmpty || hasErrors, message = s"The query had to result in a failure but it returned no errors.")
           require(requirement = warnings.nonEmpty, message = s"The query had to result in a warning but it returned no warnings.")
       }
     }

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/SchemaMapper.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/SchemaMapper.scala
@@ -38,11 +38,12 @@ object SchemaMapper extends SchemaMapper {
       for {
         objectType <- graphQlSdl.objectTypes
         fieldDef   <- objectType.fields
-        if fieldDef.directiveArgumentAsString("relation", "oldName").isDefined
+        if fieldDef.directiveArgumentAsString("relation", "name").isDefined
       } yield {
+        val next = fieldDef.directiveArgumentAsString("relation", "name").get
         Mapping(
-          previous = fieldDef.directiveArgumentAsString("relation", "oldName").get,
-          next = fieldDef.directiveArgumentAsString("relation", "name").get
+          previous = fieldDef.directiveArgumentAsString("relation", "oldName").getOrElse(next),
+          next = next
         )
       }
 
@@ -50,7 +51,7 @@ object SchemaMapper extends SchemaMapper {
       models = modelMapping,
       enums = enumMapping,
       fields = fieldMapping,
-      relations = relationMapping
+      relations = relationMapping.distinct
     )
   }
 }

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/inference/MigrationStepsInferrer.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/inference/MigrationStepsInferrer.scala
@@ -1,6 +1,6 @@
 package com.prisma.deploy.migration.inference
 
-import com.prisma.deploy.schema.UpdatedRelationAmbigous
+import com.prisma.deploy.schema.UpdatedRelationAmbiguous
 import com.prisma.shared.models._
 
 trait MigrationStepsInferrer {
@@ -258,8 +258,8 @@ case class MigrationStepsInferrerImpl(previousSchema: Schema, nextSchema: Schema
       val previousRelationCountBetweenModels = previousSchema.relations.count(relation => relation.connectsTheModels(previousModelAId, previousModelBId))
 
       if (nextRelation.name == nextGeneratedRelationName && nextRelationCountBetweenModels == 1 && previousRelationCountBetweenModels > 1)
-        throw UpdatedRelationAmbigous(
-          s"There is a relation ambiguity during the migration. The ambiguity is on a relation between ${previousRelation.modelAId} and ${previousRelation.modelBId}.")
+        throw UpdatedRelationAmbiguous(
+          s"There is a relation ambiguity during the migration. The ambiguity is on a relation between ${previousRelation.modelAId} and ${previousRelation.modelBId}. Please name relations or change the schema in steps.")
 
       val isNameRemovalOfPreviouslyNamedRelation = nextRelation.name == nextGeneratedRelationName && nextRelationCountBetweenModels == 1 && previousRelationCountBetweenModels == 1
       (relationNameMatches || isNameRemovalOfPreviouslyNamedRelation) && (refersToModelsExactlyRight || refersToModelsSwitched)
@@ -293,8 +293,8 @@ case class MigrationStepsInferrerImpl(previousSchema: Schema, nextSchema: Schema
       val nextRelationCountBetweenModels = nextSchema.relations.count(relation => relation.connectsTheModels(nextModelAId, nextModelBId))
 
       if (previousRelation.name == previousGeneratedRelationName && nextRelationCountBetweenModels > 1 && previousRelationCountBetweenModels == 1)
-        throw UpdatedRelationAmbigous(
-          s"There is a relation ambiguity during the migration. Please first name the old relation on your schema. The ambiguity is on a relation between ${previousRelation.modelAId} and ${previousRelation.modelBId}.")
+        throw UpdatedRelationAmbiguous(
+          s"There is a relation ambiguity during the migration. Please first name the old relation on your schema. The ambiguity is on a relation between ${previousRelation.modelAId} and ${previousRelation.modelBId}. Please name relations or change the schema in steps.")
 
       val isRenameOfPreviouslyUnnamedRelation = previousRelation.name == previousGeneratedRelationName && nextRelationCountBetweenModels == 1 && previousRelationCountBetweenModels == 1
 

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaErrors.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaErrors.scala
@@ -55,6 +55,11 @@ object SchemaErrors {
     )
   }
 
+  def relationDirectiveCannotAppearMoreThanTwice(fieldAndType: FieldAndType): SchemaError = {
+    val relationName = fieldAndType.fieldDef.previousRelationName.get
+    error(fieldAndType, s"A relation directive cannot appear more than twice. Relation name: '$relationName'")
+  }
+
   def selfRelationMustAppearOneOrTwoTimes(fieldAndType: FieldAndType): SchemaError = {
     val relationName = fieldAndType.fieldDef.previousRelationName.get
     error(fieldAndType, s"A relation directive for a self relation must appear either 1 or 2 times. Relation name: '$relationName'")

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaErrors.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaErrors.scala
@@ -42,9 +42,17 @@ object SchemaErrors {
     error(fieldAndType, s"""The field `${fieldAndType.fieldDef.name}` is a scalar field and cannot specify the `@relation` directive.""")
   }
 
-  def relationNameMustAppear2Times(fieldAndType: FieldAndType): SchemaError = {
+  def ambiguousRelationSinceThereIsOnlyOneRelationDirective(fieldAndType: FieldAndType): SchemaError = {
     val relationName = fieldAndType.fieldDef.previousRelationName.get
-    error(fieldAndType, s"A relation directive with a name must appear exactly 2 times. Relation name: '$relationName'")
+    val nameA        = fieldAndType.objectType.name
+    val nameB        = fieldAndType.fieldDef.fieldType.namedType.name
+    error(
+      fieldAndType,
+      s"You are trying to set the relation '$relationName' from `$nameA` to `$nameB` and are only providing a relation directive on `$nameA`. " +
+        s"Since there is also a relation field without a relation directive on `$nameB` pointing towards `$nameA` that is ambiguous. " +
+        s"Please provide the same relation directive on `$nameB` if this is supposed to be the same relation. " +
+        s"If you meant to create two separate relations without backrelations please provide a relation directive with a different name on `nameB`."
+    )
   }
 
   def selfRelationMustAppearOneOrTwoTimes(fieldAndType: FieldAndType): SchemaError = {

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaErrors.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaErrors.scala
@@ -145,6 +145,10 @@ object SchemaErrors {
     )
   }
 
+  def enumNamesMustBeUnique(enumType: EnumTypeDefinition) = {
+    error(enumType, s"The enum type `${enumType.name}` is defined twice in the schema. Enum names must be unique.")
+  }
+
   def enumValuesMustBeginUppercase(enumType: EnumTypeDefinition) = {
     error(enumType, s"The enum type `${enumType.name}` contains invalid enum values. The first character of each value must be an uppercase letter.")
   }

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaSyntaxValidator.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaSyntaxValidator.scala
@@ -152,6 +152,9 @@ case class SchemaSyntaxValidator(schema: String, directiveRequirements: Seq[Dire
       case fieldAndType if !fieldAndType.fieldDef.hasRelationDirective =>
         Left(SchemaErrors.missingRelationDirective(fieldAndType))
 
+      case fieldAndType if !isSelfRelation(fieldAndType) && relationCount(fieldAndType) > 2 =>
+        Left(SchemaErrors.relationDirectiveCannotAppearMoreThanTwice(fieldAndType))
+
       case fieldAndType if isSelfRelation(fieldAndType) && relationCount(fieldAndType) != 1 && relationCount(fieldAndType) != 2 =>
         Left(SchemaErrors.selfRelationMustAppearOneOrTwoTimes(fieldAndType))
 

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaSyntaxValidator.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/migration/validation/SchemaSyntaxValidator.scala
@@ -152,8 +152,8 @@ case class SchemaSyntaxValidator(schema: String, directiveRequirements: Seq[Dire
       case fieldAndType if !fieldAndType.fieldDef.hasRelationDirective =>
         Left(SchemaErrors.missingRelationDirective(fieldAndType))
 
-      case fieldAndType if !isSelfRelation(fieldAndType) && relationCount(fieldAndType) != 2 =>
-        Left(SchemaErrors.relationNameMustAppear2Times(fieldAndType))
+//      case fieldAndType if !isSelfRelation(fieldAndType) && relationCount(fieldAndType) != 2 =>
+//        Left(SchemaErrors.relationNameMustAppear2Times(fieldAndType))
 
       case fieldAndType if isSelfRelation(fieldAndType) && relationCount(fieldAndType) != 1 && relationCount(fieldAndType) != 2 =>
         Left(SchemaErrors.selfRelationMustAppearOneOrTwoTimes(fieldAndType))
@@ -297,7 +297,7 @@ case class SchemaSyntaxValidator(schema: String, directiveRequirements: Seq[Dire
     // TODO: this probably only works if a relation directive appears twice actually in case of ambiguous relations
 
     isSelfRelation(fieldAndType) match {
-      case true  => (fieldsOnTypeB).count(_.relationName == fieldAndType.fieldDef.relationName)
+      case true  => fieldsOnTypeB.count(_.relationName == fieldAndType.fieldDef.relationName)
       case false => (fieldsOnTypeA ++ fieldsOnTypeB).count(_.relationName == fieldAndType.fieldDef.relationName)
     }
   }

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/Errors.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/Errors.scala
@@ -21,7 +21,7 @@ object TokenExpired extends AbstractDeployApiError(s"Authentication token is exp
 
 case class InvalidQuery(reason: String) extends AbstractDeployApiError(reason, 3017)
 
-case class UpdatedRelationAmbigous(reason: String) extends AbstractDeployApiError(reason, 3018)
+case class UpdatedRelationAmbiguous(reason: String) extends AbstractDeployApiError(reason, 3018)
 
 // 40xx
 case class InvalidProjectId(projectId: ProjectId)

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/database/schema/mutations/DeployMutationSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/database/schema/mutations/DeployMutationSpec.scala
@@ -325,7 +325,6 @@ class DeployMutationSpec extends FlatSpec with Matchers with DeploySpecBase {
                           |type TestModel2 {
                           |  id: ID! @unique
                           |  test: String
-                          |  t1: TestModel
                           |}
                         """.stripMargin
 

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/migration/validation/SchemaSyntaxValidatorSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/migration/validation/SchemaSyntaxValidatorSpec.scala
@@ -87,7 +87,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
       """.stripMargin
     val result = SchemaSyntaxValidator(schema).validate
     result should have(size(4))
-    result.forall(_.description.contains("A relation directive with a name must appear exactly 2 times.")) should be(true)
+    result.forall(_.description.contains("A relation directive cannot appear more than twice.")) should be(true)
   }
 
   // TODO: the backwards field should not be required here.

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/migration/validation/SchemaSyntaxValidatorSpec.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/migration/validation/SchemaSyntaxValidatorSpec.scala
@@ -9,7 +9,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "succeed if the schema is fine" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |}
       """.stripMargin
@@ -19,7 +19,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if the schema is syntactically incorrect" in {
     val schema =
       """
-        |type Todo @model {
+        |type Todo  {
         |  title: String
         |  isDone
         |}
@@ -32,12 +32,12 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "succeed if an unambiguous relation field does not specify the relation directive" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]!
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  text: String
         |}
       """.stripMargin
@@ -48,13 +48,13 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if ambiguous relation fields do not specify the relation directive" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]!
         |  comments2: [Comment!]!
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  text: String
         |}
       """.stripMargin
@@ -73,13 +73,13 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if ambiguous relation fields specify the same relation name" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]! @relation(name: "TodoToComments")
         |  comments2: [Comment!]! @relation(name: "TodoToComments")
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  todo: Todo! @relation(name: "TodoToComments")
         |  todo2: Todo! @relation(name: "TodoToComments")
         |  text: String
@@ -94,13 +94,13 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "succeed if ambiguous relation fields specify the relation directive" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]! @relation(name: "TodoToComments1")
         |  comments2: [Comment!]! @relation(name: "TodoToComments2")
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  todo: Todo! @relation(name: "TodoToComments1")
         |  todo2: Todo! @relation(name: "TodoToComments2")
         |  text: String
@@ -113,11 +113,11 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if a relation directive appears on a scalar field" in {
     val schema =
       """
-        |type Todo @model {
+        |type Todo  {
         |  title: String @relation(name: "TodoToComments")
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  bla: String
         |}
         """.stripMargin
@@ -131,12 +131,12 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "succeed if a relation name specifies the relation directive only once" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]! @relation(name: "TodoToComments")
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  bla: String
         |}
       """.stripMargin
@@ -147,20 +147,20 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "succeed if a relation directive specifies a valid onDelete attribute" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments1: [Comment1!]! @relation(name: "TodoToComments1", onDelete: CASCADE)
         |  comments2: [Comment2!]! @relation(name: "TodoToComments2", onDelete: SET_NULL)
         |  comments3: [Comment3!]! @relation(name: "TodoToComments3")
         |}
         |
-        |type Comment1 @model{
+        |type Comment1 {
         |  bla: String
         |}
-        |type Comment2 @model{
+        |type Comment2 {
         |  bla: String
         |}
-        |type Comment3 @model{
+        |type Comment3 {
         |  bla: String
         |}
       """.stripMargin
@@ -171,12 +171,12 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if a relation directive specifies an invalid onDelete attribute" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]! @relation(name: "TodoToComments", onDelete: INVALID)
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  bla: String
         |}
       """.stripMargin
@@ -189,12 +189,12 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "succeed if a relation gets renamed" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]! @relation(name: "TodoToCommentsNew", oldName: "TodoToComments")
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  bla: String
         |  todo: Todo @relation(name: "TodoToComments")
         |}
@@ -208,7 +208,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "succeed if a one field self relation does appear only once" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  todo: Todo @relation(name: "OneFieldSelfRelation")
         |  todos: [Todo!]! @relation(name: "OneFieldManySelfRelation")
@@ -222,16 +222,16 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if the relation directive does not appear on the right fields case 1" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]! @relation(name: "TodoToComments")
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  bla: String
         |}
         |
-        |type Author @model{
+        |type Author {
         |  name: String
         |  todo: Todo @relation(name: "TodoToComments")
         |}
@@ -247,16 +247,16 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if the relation directive does not appear on the right fields case 2" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]! @relation(name: "TodoToComments")
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  bla: String
         |}
         |
-        |type Author @model{
+        |type Author {
         |  name: String
         |  whatever: Comment @relation(name: "TodoToComments")
         |}
@@ -277,12 +277,12 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "not accept that a many relation field is not marked as required" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!] @relation(name: "TodoToComments")
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  text: String
         |  todo: Todo @relation(name: "TodoToComments")
         |}
@@ -294,12 +294,12 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "succeed if a one relation field is marked as required" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]! @relation(name: "TodoToComments")
         |}
         |
-        |type Comment @model{
+        |type Comment {
         |  text: String
         |  todo: Todo! @relation(name: "TodoToComments")
         |}
@@ -311,7 +311,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if schema refers to a type that is not there" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |  comments: [Comment!]!
         |}
@@ -333,7 +333,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
     )
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String @zero @one(a: "") @two(a:1, b: "")
         |}
       """.stripMargin
@@ -349,7 +349,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
     )
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String @one(a:1) @two(a:1)
         |}
       """.stripMargin
@@ -370,7 +370,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if the values in an enum declaration don't begin uppercase" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String @one @two(a:"")
         |  status: TodoStatus
         |}
@@ -392,7 +392,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
     val longEnumValue = "A" * 192
     val schema =
       s"""
-         |type Todo @model{
+         |type Todo {
          |  title: String @one @two(a:"")
          |  status: TodoStatus
          |}
@@ -412,7 +412,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if a directive appears more than once on a field" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String @default(value: "foo") @default(value: "bar")
         |}
       """.stripMargin
@@ -427,7 +427,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if the old defaultValue directive appears on a field" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String @defaultValue(value: "foo")
         |}
       """.stripMargin
@@ -443,7 +443,7 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "fail if an id field does not specify @unique directive" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  id: ID!
         |}
       """.stripMargin
@@ -458,12 +458,36 @@ class SchemaSyntaxValidatorSpec extends WordSpecLike with Matchers {
   "not fail if a model does not specify an id field at all" in {
     val schema =
       """
-        |type Todo @model{
+        |type Todo {
         |  title: String
         |}
       """.stripMargin
     val result = SchemaSyntaxValidator(schema).validate
     result should have(size(0))
+  }
+
+  "fail if there is a duplicate enum in datamodel" in {
+    val schema =
+      """
+        |type Todo {
+        |  id: ID! @unique
+        |}
+        |
+        |enum Privacy {
+        |  A
+        |  B
+        |}
+        |
+        |enum Privacy {
+        |  C
+        |}
+      """.stripMargin
+    val result = SchemaSyntaxValidator(schema).validate
+    result should have(size(1))
+    val error1 = result.head
+    error1.`type` should equal("Privacy")
+    error1.field should equal(None)
+    error1.description should include(s"The enum type `Privacy` is defined twice in the schema. Enum names must be unique.")
   }
 
   def missingDirectiveArgument(directive: String, argument: String) = {

--- a/server/shared-models/src/main/scala/com/prisma/shared/models/Models.scala
+++ b/server/shared-models/src/main/scala/com/prisma/shared/models/Models.scala
@@ -93,8 +93,7 @@ case class Schema(
   def getEnumByName(name: String): Option[Enum] = enums.find(_.name.toLowerCase == name.toLowerCase)
 
   def getRelationByName(name: String): Option[Relation] = relations.find(_.name == name)
-  def getRelationByName_!(name: String): Relation =
-    getRelationByName(name).get //OrElse(throw SystemErrors.InvalidRelation("There is no relation with name: " + name))
+  def getRelationByName_!(name: String): Relation       = getRelationByName(name).get
 
   def getRelationsThatConnectModels(modelA: String, modelB: String): List[Relation] = relations.filter(_.connectsTheModels(modelA, modelB))
 
@@ -377,9 +376,7 @@ case class Relation(
   def getModelB_!(schema: Schema): Model       = getModelB(schema).get //OrElse(throw SystemErrors.InvalidRelation("A relation should have a valid Model B."))
 
   def getModelAField(schema: Schema): Option[Field] = modelFieldFor(schema, modelAId, RelationSide.A)
-  def getModelBField(schema: Schema): Option[Field] = {
-    modelFieldFor(schema, modelBId, RelationSide.B)
-  }
+  def getModelBField(schema: Schema): Option[Field] = modelFieldFor(schema, modelBId, RelationSide.B)
 
   private def modelFieldFor(schema: Schema, modelId: String, relationSide: RelationSide.Value): Option[Field] = {
     for {


### PR DESCRIPTION
Do not strictly require a relation directive to appear twice anymore. https://github.com/graphcool/prisma/issues/1569 , 
Add a validation when adding an omitted back relation later. (If it's a to one relation the omitted side can only be in one relation in existing data.) 
Add an error if we can not determine which relation operations to take after a schema change. Add a hint to provide relation directives or advance in steps. https://github.com/graphcool/prisma/issues/1836
Added tests for a case described here that was already fixed. https://github.com/graphcool/prisma/issues/1944

Fixes https://github.com/graphcool/prisma/issues/1569 , https://github.com/graphcool/prisma/issues/1836