### PR TITLE
docs: sync docker-compose.yml example in docker/upgrade guide to 1.7

### DIFF
--- a/docs/1.7/04-Reference/05-Prisma-Servers-&-DBs/01-Prisma-Servers/02-Docker.md
+++ b/docs/1.7/04-Reference/05-Prisma-Servers-&-DBs/01-Prisma-Servers/02-Docker.md
@@ -57,6 +57,7 @@ services:
             user: root
             password: prisma
   db:
+    container_name: prisma-db
     image: mysql:5.7
     restart: always
     environment:

--- a/docs/1.7/04-Reference/09-Upgrade-Guides/02-Upgrading-Prisma/02-Upgrade-to-1.7.md
+++ b/docs/1.7/04-Reference/09-Upgrade-Guides/02-Upgrading-Prisma/02-Upgrade-to-1.7.md
@@ -136,6 +136,7 @@ services:
         databases:
           default:
             connector: mysql  # or `postgres`
+            active: true
             host: db
             port: 3306        # or `5432` for `postgres`
             user: root


### PR DESCRIPTION
This PR attempts to bring the `docker-compose.yml` examples in sync with each other on the following pages. 

https://www.prisma.io/docs/reference/prisma-servers-and-dbs/prisma-servers/docker-aira9zama5

https://www.prisma.io/docs/reference/upgrade-guides/upgrading-prisma/upgrade-to-1.7-iquaecuj6b

This sync is more important because when `active: true` is omitted from `docker-compose.yml` file, it leads to a cluster restart loop with `docker logs database_prisma_1` yielding an error regarding `active` being required. 

Also, note that `active` field is to be renamed to `migrations` soon. 