### PR TITLE
Detect when setting a unique constraint is not possible

### DIFF
--- a/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/database/MysqlDeployDatabaseQueryBuilder.scala
+++ b/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/database/MysqlDeployDatabaseQueryBuilder.scala
@@ -19,6 +19,15 @@ object MysqlDeployDatabaseQueryBuilder {
     sql"select exists (select Count(*)from `#$projectId`.`#$relationTableName` Group by `#${relationSide.toString}` having Count(*) > 1)"
   }
 
+  def existsDuplicateValueByModelAndField(projectId: String, modelName: String, fieldName: String) = {
+    sql"""SELECT EXISTS(
+             Select Count(*)
+             FROM `#$projectId`.`#$modelName`
+             GROUP BY `#$fieldName`
+             HAVING COUNT(*) > 1
+          )"""
+  }
+
   def existsNullByModelAndScalarField(projectId: String, modelName: String, fieldName: String) = {
     sql"""SELECT EXISTS(Select `id` FROM `#$projectId`.`#$modelName`
           WHERE `#$projectId`.`#$modelName`.#$fieldName IS NULL)"""

--- a/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/impls/MysqlClientDbQueries.scala
+++ b/server/connectors/deploy-connector-mysql/src/main/scala/com/prisma/deploy/connector/mysql/impls/MysqlClientDbQueries.scala
@@ -36,6 +36,11 @@ case class MysqlClientDbQueries(project: Project, clientDatabase: Database)(impl
     clientDatabase.run(readOnlyBoolean(query)).map(_.head).recover { case _: java.sql.SQLSyntaxErrorException => false }
   }
 
+  def existsDuplicateValueByModelAndField(model: Model, field: Field): Future[Boolean] = {
+    val query = MysqlDeployDatabaseQueryBuilder.existsDuplicateValueByModelAndField(project.id, model.name, field.name)
+    clientDatabase.run(readOnlyBoolean(query)).map(_.head).recover { case _: java.sql.SQLSyntaxErrorException => false }
+  }
+
   override def enumValueIsInUse(models: Vector[Model], enumName: String, value: String): Future[Boolean] = {
     val query = MysqlDeployDatabaseQueryBuilder.enumValueIsInUse(project.id, models, enumName, value)
     clientDatabase.run(readOnlyBoolean(query)).map(_.head).recover { case _: java.sql.SQLSyntaxErrorException => false }

--- a/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/database/PostgresDeployDatabaseQueryBuilder.scala
+++ b/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/database/PostgresDeployDatabaseQueryBuilder.scala
@@ -24,6 +24,15 @@ object PostgresDeployDatabaseQueryBuilder {
           WHERE "#$projectId"."#$modelName".#$fieldName IS NULL)"""
   }
 
+  def existsDuplicateValueByModelAndField(projectId: String, modelName: String, fieldName: String) = {
+    sql"""SELECT EXISTS(
+             Select Count(*)
+             FROM "#$projectId"."#$modelName"
+             GROUP BY "#$fieldName"
+             HAVING COUNT(*) > 1
+          )"""
+  }
+
   def existsNullByModelAndRelationField(projectId: String, modelName: String, field: Field) = {
     val relationId   = field.relation.get.relationTableName
     val relationSide = field.relationSide.get.toString

--- a/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/impls/PostgresClientDbQueries.scala
+++ b/server/connectors/deploy-connector-postgresql/src/main/scala/com/prisma/deploy/connector/postgresql/impls/PostgresClientDbQueries.scala
@@ -36,6 +36,11 @@ case class PostgresClientDbQueries(project: Project, clientDatabase: Database)(i
     clientDatabase.run(readOnlyBoolean(query)).map(_.head).recover { case _: java.sql.SQLSyntaxErrorException => false }
   }
 
+  def existsDuplicateValueByModelAndField(model: Model, field: Field): Future[Boolean] = {
+    val query = PostgresDeployDatabaseQueryBuilder.existsDuplicateValueByModelAndField(project.id, model.name, field.name)
+    clientDatabase.run(readOnlyBoolean(query)).map(_.head).recover { case _: java.sql.SQLSyntaxErrorException => false }
+  }
+
   override def enumValueIsInUse(models: Vector[Model], enumName: String, value: String): Future[Boolean] = {
     val query = PostgresDeployDatabaseQueryBuilder.enumValueIsInUse(project.id, models, enumName, value)
     clientDatabase.run(readOnlyBoolean(query)).map(_.head).recover { case _: java.sql.SQLSyntaxErrorException => false }

--- a/server/connectors/deploy-connector/src/main/scala/com/prisma/deploy/connector/DeployConnector.scala
+++ b/server/connectors/deploy-connector/src/main/scala/com/prisma/deploy/connector/DeployConnector.scala
@@ -36,5 +36,6 @@ trait ClientDbQueries {
   def existsByRelation(relationId: String): Future[Boolean]
   def existsDuplicateByRelationAndSide(relationId: String, side: RelationSide): Future[Boolean]
   def existsNullByModelAndField(model: Model, field: Field): Future[Boolean]
+  def existsDuplicateValueByModelAndField(model: Model, field: Field): Future[Boolean]
   def enumValueIsInUse(models: Vector[Model], enumName: String, value: String): Future[Boolean]
 }

--- a/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/DeployingUniqueConstraintSpec.scala
+++ b/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/DeployingUniqueConstraintSpec.scala
@@ -1,0 +1,98 @@
+package com.prisma.integration
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class DeployingUniqueConstraintSpec extends FlatSpec with Matchers with IntegrationBaseSpec {
+
+  "Adding a unique constraint with violating data" should "throw a deploy error" in {
+
+    val schema =
+      """type Team {
+        |  name: String! @unique
+        |  dummy: String
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query("""mutation{createTeam(data:{name:"Bayern", dummy: "String"}){name}}""", project)
+    apiServer.query("""mutation{createTeam(data:{name:"Real", dummy: "String"}){name}}""", project)
+
+    val schema1 =
+      """type Team {
+        |  name: String! @unique
+        |  dummy: String @unique
+        |}"""
+
+    val res = deployServer.deploySchemaThatMustError(project, schema1)
+    res.toString should be(
+      """{"data":{"deploy":{"migration":{"applied":0,"revision":0},"errors":[{"description":"You are making a field unique, but there are already nodes that would violate that constraint."}],"warnings":[]}}}""")
+  }
+
+  "Adding a unique constraint without violating data" should "work" in {
+
+    val schema =
+      """type Team {
+        |  name: String! @unique
+        |  dummy: String
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query("""mutation{createTeam(data:{name:"Bayern", dummy: "String"}){name}}""", project)
+    apiServer.query("""mutation{createTeam(data:{name:"Real", dummy: "String2"}){name}}""", project)
+
+    val schema1 =
+      """type Team {
+        |  name: String! @unique
+        |  dummy: String @unique
+        |}"""
+
+    deployServer.deploySchemaThatMustSucceed(project, schema1, 3)
+  }
+
+  "Adding a new String field with a unique constraint" should "work" in {
+
+    val schema =
+      """type Team {
+        |  name: String! @unique
+        |  dummy: String
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query("""mutation{createTeam(data:{name:"Bayern", dummy: "String"}){name}}""", project)
+    apiServer.query("""mutation{createTeam(data:{name:"Real", dummy: "String2"}){name}}""", project)
+
+    val schema1 =
+      """type Team {
+        |  name: String! @unique
+        |  dummy: String
+        |  newField: String @unique
+        |}"""
+
+    deployServer.deploySchemaThatMustSucceed(project, schema1, 3)
+  }
+
+  "Adding a new Int field with a unique constraint" should "work" in {
+
+    val schema =
+      """type Team {
+        |  name: String! @unique
+        |  dummy: String
+        |}"""
+
+    val (project, _) = setupProject(schema)
+
+    apiServer.query("""mutation{createTeam(data:{name:"Bayern", dummy: "String"}){name}}""", project)
+    apiServer.query("""mutation{createTeam(data:{name:"Real", dummy: "String2"}){name}}""", project)
+
+    val schema1 =
+      """type Team {
+        |  name: String! @unique
+        |  dummy: String
+        |  newField: Int @unique
+        |}"""
+
+    deployServer.deploySchemaThatMustSucceed(project, schema1, 3)
+  }
+}

--- a/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/DeployingUniqueConstraintSpec.scala
+++ b/server/integration-tests/integration-tests-mysql/src/test/scala/com/prisma/integration/DeployingUniqueConstraintSpec.scala
@@ -73,7 +73,7 @@ class DeployingUniqueConstraintSpec extends FlatSpec with Matchers with Integrat
     deployServer.deploySchemaThatMustSucceed(project, schema1, 3)
   }
 
-  "Adding a new required String field with a unique constraint" should "work" in {
+  "Adding a new required String field with a unique constraint" should "error" in {
 
     val schema =
       """type Team {


### PR DESCRIPTION
Setting a  unique constraint will error if there are already duplicates present in the case of a field update or if a new field is required and unique since SQL will set default values for the newly required fields. This adds a validation up front and will abort the deploy already while inferring the necessary changes and not only once we change the database.

Fixes 
https://github.com/graphcool/prisma/issues/1773
https://github.com/graphcool/prisma/issues/1894
https://github.com/graphcool/prisma/issues/2011
https://github.com/graphcool/prisma/issues/2170
https://github.com/graphcool/prisma/issues/2121