### PR TITLE
Reintroduce /cluster for backwards compatibility

### DIFF
--- a/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalDependencies.scala
+++ b/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalDependencies.scala
@@ -1,6 +1,6 @@
 package com.prisma.local
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, Props}
 import akka.stream.ActorMaterializer
 import com.prisma.akkautil.http.SimpleHttpClient
 import com.prisma.api.ApiDependencies
@@ -12,6 +12,7 @@ import com.prisma.config.{ConfigLoader, PrismaConfig}
 import com.prisma.connectors.utils.ConnectorUtils
 import com.prisma.deploy.DeployDependencies
 import com.prisma.deploy.migration.migrator.{AsyncMigrator, Migrator}
+import com.prisma.deploy.server.TelemetryActor
 import com.prisma.deploy.server.auth.{AsymmetricManagementAuth, DummyManagementAuth, SymmetricManagementAuth}
 import com.prisma.image.{Converters, FunctionValidatorImpl, SingleServerProjectFetcher}
 import com.prisma.messagebus.pubsub.inmemory.InMemoryAkkaPubSub
@@ -99,4 +100,6 @@ case class PrismaLocalDependencies()(implicit val system: ActorSystem, val mater
   override lazy val apiConnector                  = ConnectorUtils.loadApiConnector(config)
   override lazy val sideEffectMutactionExecutor   = SideEffectMutactionExecutorImpl()
   override lazy val mutactionVerifier             = DatabaseMutactionVerifierImpl
+
+  lazy val telemetryActor = system.actorOf(Props(TelemetryActor(deployConnector)))
 }

--- a/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalMain.scala
+++ b/server/images/prisma-local/src/main/scala/com/prisma/local/PrismaLocalMain.scala
@@ -20,6 +20,7 @@ object PrismaLocalMain extends App {
   ServerExecutor(
     port = dependencies.config.port.getOrElse(4466),
     ManagementServer("management", dependencies.config.server2serverSecret),
+    ManagementServer("cluster", dependencies.config.server2serverSecret), // Deprecated, will be removed soon
     WebsocketServer(dependencies),
     ApiServer(dependencies.apiSchemaBuilder),
     SimpleSubscriptionsServer(),

--- a/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
+++ b/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdDependencies.scala
@@ -1,6 +1,6 @@
 package com.prisma.prod
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, Props}
 import akka.stream.ActorMaterializer
 import com.prisma.akkautil.http.SimpleHttpClient
 import com.prisma.api.ApiDependencies
@@ -14,6 +14,7 @@ import com.prisma.deploy.DeployDependencies
 import com.prisma.deploy.connector.DeployConnector
 import com.prisma.deploy.migration.migrator.{AsyncMigrator, Migrator}
 import com.prisma.deploy.schema.mutations.FunctionValidator
+import com.prisma.deploy.server.TelemetryActor
 import com.prisma.deploy.server.auth.{AsymmetricManagementAuth, DummyManagementAuth, SymmetricManagementAuth}
 import com.prisma.image.{Converters, FunctionValidatorImpl, SingleServerProjectFetcher}
 import com.prisma.messagebus._
@@ -113,4 +114,6 @@ case class PrismaProdDependencies()(implicit val system: ActorSystem, val materi
   override lazy val apiConnector                = ConnectorUtils.loadApiConnector(config)
   override lazy val sideEffectMutactionExecutor = SideEffectMutactionExecutorImpl()
   override lazy val mutactionVerifier           = DatabaseMutactionVerifierImpl
+
+  lazy val telemetryActor = system.actorOf(Props(TelemetryActor(deployConnector)))
 }

--- a/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdMain.scala
+++ b/server/images/prisma-prod/src/main/scala/com/prisma/prod/PrismaProdMain.scala
@@ -19,7 +19,13 @@ object PrismaProdMain extends App {
 
   val port              = dependencies.config.port.getOrElse(4466)
   val includeMgmtServer = dependencies.config.managmentApiEnabled
-  val servers = includeMgmtServer.flatMap(_.toOption(ManagementServer("management", dependencies.config.server2serverSecret))) ++ List(
+  val mgmtServer = includeMgmtServer.flatMap(_.toOption(
+    List(
+      ManagementServer("management", dependencies.config.server2serverSecret),
+      ManagementServer("cluster", dependencies.config.server2serverSecret) // Deprecated, will be removed soon
+  ))).toList.flatten
+
+  val servers = mgmtServer ++ List(
     WebsocketServer(dependencies),
     ApiServer(dependencies.apiSchemaBuilder),
     SimpleSubscriptionsServer(),
@@ -28,6 +34,6 @@ object PrismaProdMain extends App {
 
   ServerExecutor(
     port = port,
-    servers = servers.toSeq: _*
+    servers = servers: _*
   ).startBlocking()
 }

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/DeployDependencies.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/DeployDependencies.scala
@@ -1,6 +1,6 @@
 package com.prisma.deploy
 
-import akka.actor.{ActorSystem, Props}
+import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.stream.ActorMaterializer
 import com.prisma.auth.Auth
 import com.prisma.deploy.connector.DeployConnector
@@ -29,6 +29,7 @@ trait DeployDependencies extends AwaitUtils {
   def deployConnector: DeployConnector
   def functionValidator: FunctionValidator
   def projectIdEncoder: ProjectIdEncoder
+  def telemetryActor: ActorRef
 
   lazy val projectPersistence      = deployConnector.projectPersistence
   lazy val migrationPersistence    = deployConnector.migrationPersistence

--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/ManagementServer.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/ManagementServer.scala
@@ -44,7 +44,7 @@ case class ManagementServer(prefix: String = "", server2serverSecret: Option[Str
   val requestPrefix                          = sys.env.getOrElse("ENV", "local")
   val schemaManagerSecured                   = server2serverSecret.exists(_.nonEmpty)
   val projectIdEncoder                       = dependencies.projectIdEncoder
-  val telemetryActor                         = system.actorOf(Props(TelemetryActor(dependencies.deployConnector)))
+  val telemetryActor                         = dependencies.telemetryActor
 
   def errorExtractor(t: Throwable): Option[Int] = t match {
     case e: DeployApiError => Some(e.code)

--- a/server/servers/deploy/src/test/scala/com/prisma/deploy/specutils/TestDeployDependencies.scala
+++ b/server/servers/deploy/src/test/scala/com/prisma/deploy/specutils/TestDeployDependencies.scala
@@ -2,6 +2,7 @@ package com.prisma.deploy.specutils
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.testkit.TestProbe
 import com.prisma.auth.AuthImpl
 import com.prisma.config.ConfigLoader
 import com.prisma.connectors.utils.ConnectorUtils
@@ -34,4 +35,6 @@ case class TestDeployDependencies()(implicit val system: ActorSystem, val materi
   override def functionValidator: FunctionValidator = (project: Project, fn: FunctionInput) => {
     if (fn.name == "failing") Vector(SchemaError(`type` = "model", field = "field", description = "error")) else Vector.empty
   }
+
+  lazy val telemetryActor = TestProbe().ref
 }


### PR DESCRIPTION
This route is still (as of 1.8) deprecated and will be removed again in the future.